### PR TITLE
feat: dashboard improvements + dark/light theme

### DIFF
--- a/app/backend/db.py
+++ b/app/backend/db.py
@@ -49,4 +49,153 @@ def init_db():
             db.execute(f"ALTER TABLE events ADD COLUMN {col} TEXT DEFAULT '{default}'")
 
     db.execute("CREATE INDEX IF NOT EXISTS idx_events_external_ref ON events(source, external_ref)")
+
+    # ── Indicators (IoC) ────────────────────────────────────────────
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS indicators (
+            id TEXT PRIMARY KEY,
+            node_id TEXT NOT NULL,
+            company TEXT NOT NULL,
+            type TEXT NOT NULL DEFAULT 'ip',
+            value TEXT NOT NULL,
+            tlp TEXT NOT NULL DEFAULT 'AMBER',
+            description TEXT DEFAULT '',
+            severity TEXT DEFAULT 'medium',
+            created_at TEXT NOT NULL,
+            signature TEXT DEFAULT ''
+        )
+    """)
+    db.execute("CREATE INDEX IF NOT EXISTS idx_indicators_created ON indicators(created_at)")
+    db.execute("CREATE INDEX IF NOT EXISTS idx_indicators_tlp ON indicators(tlp)")
+
+    # ── Chat messages (per-event discussion) ────────────────────────
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS chat_messages (
+            id TEXT PRIMARY KEY,
+            event_id TEXT NOT NULL,
+            node_id TEXT NOT NULL,
+            company TEXT NOT NULL,
+            author TEXT NOT NULL DEFAULT '',
+            message TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            signature TEXT DEFAULT ''
+        )
+    """)
+    db.execute("CREATE INDEX IF NOT EXISTS idx_chat_event ON chat_messages(event_id, created_at)")
+    db.execute("CREATE INDEX IF NOT EXISTS idx_chat_created ON chat_messages(created_at)")
+
+    # ── Vulnerabilities ─────────────────────────────────────────────
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS vulnerabilities (
+            id TEXT PRIMARY KEY,
+            cve_id TEXT NOT NULL DEFAULT '',
+            cvss_score REAL DEFAULT 0.0,
+            severity TEXT DEFAULT 'medium',
+            title TEXT NOT NULL,
+            description TEXT DEFAULT '',
+            asset TEXT DEFAULT '',
+            status TEXT DEFAULT 'open',
+            created_at TEXT NOT NULL
+        )
+    """)
+    db.execute("CREATE INDEX IF NOT EXISTS idx_vuln_status ON vulnerabilities(status)")
+    db.execute("CREATE INDEX IF NOT EXISTS idx_vuln_severity ON vulnerabilities(severity)")
+    db.execute("CREATE INDEX IF NOT EXISTS idx_vuln_cve ON vulnerabilities(cve_id)")
+
+    db.commit()
+
+
+def seed_vulnerabilities():
+    """Pre-populate known OT CVEs if the table is empty."""
+    db = get_db()
+    count = db.execute("SELECT COUNT(*) FROM vulnerabilities").fetchone()[0]
+    if count > 0:
+        return
+
+    import uuid
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+
+    cves = [
+        ("CVE-2023-2611", 9.8, "critical", "ABB Relion 615/620 — Uautentisert tilgang",
+         "Uautentisert ekstern tilgang til vernreleets konfigurasjon via HMI-grensesnitt. Ingen pålogging kreves.",
+         "ABB Relion 615 serie"),
+        ("CVE-2022-31806", 9.8, "critical", "CODESYS Runtime — Standardpassord",
+         "CODESYS V3 runtime bruker svakt standardpassord som gir full kontroll over PLC-logikk.",
+         "CODESYS V3 PLC-er"),
+        ("CVE-2024-3400", 10.0, "critical", "Palo Alto PAN-OS — Command Injection",
+         "Uautentisert kommandoinjeksjon via GlobalProtect-gateway. Aktivt utnyttet i norsk infrastruktur.",
+         "Palo Alto brannmur"),
+        ("CVE-2023-3595", 9.8, "critical", "Rockwell ControlLogix — Remote Code Execution",
+         "Kritisk RCE i Rockwell ControlLogix/GuardLogix. Kan endre PLC-program uten autentisering.",
+         "Rockwell ControlLogix 1756"),
+        ("CVE-2022-2097", 5.3, "medium", "OpenSSL AES-OCB — Ukrypterte bytes",
+         "AES-OCB-modus krypterer ikke alle bytes på 32-bit x86. Relevant for OT-systemer med eldre hardware.",
+         "OT gateway (OpenSSL)"),
+        ("CVE-2023-46747", 9.8, "critical", "F5 BIG-IP — Autentiseringsbypass",
+         "Undone AJ-AJAX-endepunkt lar angripere omgå autentisering og kjøre vilkårlig kode.",
+         "F5 BIG-IP (DMZ)"),
+        ("CVE-2024-21762", 9.6, "critical", "Fortinet FortiOS — Out-of-bound Write",
+         "SSL-VPN-sårbarhet som gir uautentisert RCE. Aktivt utnyttet mot norske virksomheter.",
+         "FortiGate brannmur"),
+        ("CVE-2023-0286", 7.4, "high", "OpenSSL X.509 — Type Confusion",
+         "X.509 GeneralName type confusion kan lede til minnelekkasje eller DoS i TLS-autentisering.",
+         "SCADA gateway (TLS)"),
+        ("CVE-2022-22965", 9.8, "critical", "Spring4Shell — Remote Code Execution",
+         "RCE i Spring Framework via data binding. Relevant for Java-baserte SCADA-webgrensesnitt.",
+         "EMS webgrensesnitt"),
+        ("CVE-2023-44487", 7.5, "high", "HTTP/2 Rapid Reset — DoS",
+         "HTTP/2 rapid reset-angrep (DDoS). Kan ta ned OT-webgrensesnitt og API-endepunkter.",
+         "Alle HTTP/2-tjenester"),
+        ("CVE-2024-0012", 9.8, "critical", "Palo Alto PAN-OS — Authentication Bypass",
+         "Bypass av autentisering i management-grensesnitt. Gir full admin-tilgang uten legitimering.",
+         "Palo Alto (mgmt)"),
+        ("CVE-2023-20198", 10.0, "critical", "Cisco IOS XE — Web UI Privilege Escalation",
+         "Uautentisert opprettelse av admin-konto via web-UI. Aktivt utnyttet globalt.",
+         "Cisco nettverksutstyr"),
+    ]
+
+    for cve_id, cvss, sev, title, desc, asset in cves:
+        db.execute(
+            """INSERT INTO vulnerabilities (id, cve_id, cvss_score, severity, title, description, asset, status, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'open', ?)""",
+            (str(uuid.uuid4()), cve_id, cvss, sev, title, desc, asset, now),
+        )
+    db.commit()
+
+
+def seed_indicators():
+    """Pre-populate demo IoCs if the table is empty."""
+    db = get_db()
+    count = db.execute("SELECT COUNT(*) FROM indicators").fetchone()[0]
+    if count > 0:
+        return
+
+    import uuid
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+    node_id = os.environ.get("NODE_ID", "unknown")
+    company = os.environ.get("COMPANY", node_id)
+
+    iocs = [
+        ("ip", "185.220.101.34", "RED", "high", "Tor exit-node sett i scanning mot SCADA-port 502"),
+        ("ip", "91.219.236.222", "RED", "critical", "C2-server brukt i Sandworm-kampanje mot energisektor"),
+        ("ip", "45.155.205.99", "AMBER", "high", "Brute-force SSH mot OT-jumphost, 12k forsøk/time"),
+        ("domain", "update-scada.kfraud.ru", "RED", "critical", "Phishing-domene som imiterer SCADA-oppdatering"),
+        ("domain", "vpn-portal-kraft.com", "AMBER", "high", "Falsk VPN-portal som høster legitimering"),
+        ("hash", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6", "AMBER", "medium", "SHA-256 av malware-dropper funnet i e-postvedlegg"),
+        ("hash", "deadbeef01234567deadbeef01234567", "RED", "critical", "Industroyer2 variant — SHA-256 av payload"),
+        ("ip", "193.142.30.166", "AMBER", "medium", "Scanning mot IEC 104-porter (2404) fra dette IP-et"),
+        ("ttp", "T1190 — Exploit Public-Facing Application", "GREEN", "medium", "Observert mot FortiGate VPN i norsk kraftsektor"),
+        ("ttp", "T1078.004 — Valid Accounts: Cloud Accounts", "AMBER", "high", "Kompromittert Azure AD-konto brukt mot OT-tilgang"),
+        ("domain", "cdn-kraftcert-no.xyz", "RED", "critical", "Typosquatting av KraftCERT — distribuerer bakdør"),
+        ("ip", "23.106.215.76", "GREEN", "low", "Scanning mot DNS-porter — lav konfidens, overvåking"),
+    ]
+
+    for ioc_type, value, tlp, sev, desc in iocs:
+        db.execute(
+            """INSERT INTO indicators (id, node_id, company, type, value, tlp, description, severity, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (str(uuid.uuid4()), node_id, company, ioc_type, value, tlp, desc, sev, now),
+        )
     db.commit()

--- a/app/backend/gossip.py
+++ b/app/backend/gossip.py
@@ -187,6 +187,40 @@ def push_event(event: dict, exclude: str | None = None):
             _log_activity("push_fail", peer)
 
 
+def push_indicator(indicator: dict, exclude: str | None = None):
+    """Push a single IoC to healthy peers."""
+    hops = indicator.get("hops", MAX_HOPS)
+    if hops <= 0:
+        return
+    data = {**indicator, "hops": hops - 1}
+    for peer in _get_healthy_peers():
+        if peer == exclude:
+            continue
+        try:
+            httpx.post(f"{peer}/indicators/sync", json=[data], timeout=3)
+            _mark_peer_ok(peer)
+            _log_activity("push", peer, detail=f"IoC: {indicator.get('value','')}", count=1)
+        except Exception:
+            _mark_peer_fail(peer)
+
+
+def push_chat(message: dict, exclude: str | None = None):
+    """Push a chat message to healthy peers."""
+    hops = message.get("hops", MAX_HOPS)
+    if hops <= 0:
+        return
+    data = {**message, "hops": hops - 1}
+    for peer in _get_healthy_peers():
+        if peer == exclude:
+            continue
+        try:
+            httpx.post(f"{peer}/chat/sync", json=[data], timeout=3)
+            _mark_peer_ok(peer)
+            _log_activity("push", peer, detail="chat", count=1)
+        except Exception:
+            _mark_peer_fail(peer)
+
+
 # ── Pull (sync) ─────────────────────────────────────────────────────
 
 
@@ -261,6 +295,7 @@ def _sync_once():
     _sync_identities()
 
     for peer in get_peers():
+        # ── Pull events ──
         try:
             cursor = _last_seen_for_peer(peer)
             resp = httpx.get(f"{peer}/events/since/{cursor}", timeout=5)
@@ -268,19 +303,48 @@ def _sync_once():
             _mark_peer_ok(peer)
             if not events:
                 _log_activity("pull_empty", peer)
-                continue
-            # Pull-synced events get hops=0 so they don't re-push
-            for e in events:
-                e["hops"] = 0
-            httpx.post("http://localhost:8000/events/sync", json=events, timeout=5)
-            latest = max(e["created_at"] for e in events)
-            _update_cursor(peer, latest)
-            _log_activity("pull", peer, count=len(events))
-            log.info(f"Pulled {len(events)} events from {peer}")
+            else:
+                for e in events:
+                    e["hops"] = 0
+                httpx.post("http://localhost:8000/events/sync", json=events, timeout=5)
+                latest = max(e["created_at"] for e in events)
+                _update_cursor(peer, latest)
+                _log_activity("pull", peer, count=len(events))
+                log.info(f"Pulled {len(events)} events from {peer}")
         except Exception as e:
             _mark_peer_fail(peer)
             _log_activity("pull_fail", peer)
             log.warning(f"Pull failed for {peer}: {e}")
+
+        # ── Pull indicators ──
+        try:
+            cursor = _last_seen_for_peer(f"ind:{peer}")
+            resp = httpx.get(f"{peer}/indicators/since/{cursor}", timeout=5)
+            indicators = resp.json()
+            if indicators:
+                for ind in indicators:
+                    ind["hops"] = 0
+                httpx.post("http://localhost:8000/indicators/sync", json=indicators, timeout=5)
+                latest = max(i["created_at"] for i in indicators)
+                _update_cursor(f"ind:{peer}", latest)
+                log.info(f"Pulled {len(indicators)} indicators from {peer}")
+        except Exception:
+            pass
+
+        # ── Pull chat messages ──
+        try:
+            cursor = _last_seen_for_peer(f"chat:{peer}")
+            resp = httpx.get(f"{peer}/chat/since/{cursor}", timeout=5)
+            messages = resp.json()
+            if messages:
+                for m in messages:
+                    m["hops"] = 0
+                httpx.post("http://localhost:8000/chat/sync", json=messages, timeout=5)
+                latest = max(m["created_at"] for m in messages)
+                _update_cursor(f"chat:{peer}", latest)
+                log.info(f"Pulled {len(messages)} chat messages from {peer}")
+        except Exception:
+            pass
 
 
 # ── Loop ────────────────────────────────────────────────────────────

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
-from db import init_db, get_db
+from db import init_db, get_db, seed_vulnerabilities, seed_indicators
 from identity import (
     init_identity_db, create_invite, validate_invite,
     register_peer, get_all_peers, get_peer_identity, is_trusted,
@@ -64,6 +64,8 @@ def startup():
     global _private_key, _public_key
     init_db()
     init_identity_db()
+    seed_vulnerabilities()
+    seed_indicators()
 
     from crypto import generate_keypair, get_public_key_pem
     _private_key, _public_key = generate_keypair()
@@ -78,6 +80,13 @@ def startup():
         threading.Thread(
             target=_auto_register, args=(kraftcert_url, invite_token), daemon=True
         ).start()
+
+    # Populate gossip peer set from identity DB (survives restarts)
+    from gossip import add_peer
+    for peer in get_all_peers():
+        url = peer.get("public_url", "").strip().rstrip("/")
+        if url and peer.get("node_id") != NODE_ID:
+            add_peer(url)
 
     from gossip import start_gossip_loop
     start_gossip_loop()
@@ -209,6 +218,31 @@ def ui_topology_debug():
     return FileResponse(os.path.join(_STATIC_DIR, "topology-debug.html"))
 
 
+@app.get("/events/ui")
+def ui_events():
+    return FileResponse(os.path.join(_STATIC_DIR, "events.html"))
+
+
+@app.get("/events/ui/detail")
+def ui_event_detail():
+    return FileResponse(os.path.join(_STATIC_DIR, "event-detail.html"))
+
+
+@app.get("/indicators/ui")
+def ui_indicators():
+    return FileResponse(os.path.join(_STATIC_DIR, "indicators.html"))
+
+
+@app.get("/vulnerabilities/ui")
+def ui_vulnerabilities():
+    return FileResponse(os.path.join(_STATIC_DIR, "vulnerabilities.html"))
+
+
+@app.get("/chat/ui")
+def ui_chat():
+    return FileResponse(os.path.join(_STATIC_DIR, "chat.html"))
+
+
 # ── Health & discovery ──────────────────────────────────────────────
 
 
@@ -244,10 +278,18 @@ def stats():
         "role": ROLE,
         "events": {"total": events_total, "last_24h": events_24h, "critical_24h": events_critical_24h},
         "peers": {"online": peers_online, "total": peers_total},
-        # placeholders inntil sprint 1-tabellene er på plass
-        "vulnerabilities": {"open": 0, "critical": 0},
-        "indicators": {"total": 0, "tlp_red": 0, "tlp_amber": 0},
-        "incidents": {"open": 0},
+        "vulnerabilities": {
+            "open": db.execute("SELECT COUNT(*) FROM vulnerabilities WHERE status='open'").fetchone()[0],
+            "critical": db.execute("SELECT COUNT(*) FROM vulnerabilities WHERE status='open' AND severity='critical'").fetchone()[0],
+        },
+        "indicators": {
+            "total": db.execute("SELECT COUNT(*) FROM indicators").fetchone()[0],
+            "tlp_red": db.execute("SELECT COUNT(*) FROM indicators WHERE tlp='RED'").fetchone()[0],
+            "tlp_amber": db.execute("SELECT COUNT(*) FROM indicators WHERE tlp='AMBER'").fetchone()[0],
+        },
+        "incidents": {
+            "open": db.execute("SELECT COUNT(*) FROM events WHERE severity IN ('critical','high')").fetchone()[0],
+        },
         "tools": {"installed": 0},
     }
 
@@ -612,3 +654,217 @@ def sync_events(events: list[Event]):
         if ev.get("hops", 0) > 0:
             threading.Thread(target=push_event, args=(ev,), daemon=True).start()
     return {"inserted": len(new_events)}
+
+
+# ── Indicators (IoC) ────────────────────────────────────────────────
+
+
+class IndicatorIn(BaseModel):
+    type: str = "ip"       # ip / hash / domain / ttp
+    value: str
+    tlp: str = "AMBER"     # RED / AMBER / GREEN / WHITE
+    description: str = ""
+    severity: str = "medium"
+
+
+class Indicator(BaseModel):
+    id: str
+    node_id: str
+    company: str
+    type: str
+    value: str
+    tlp: str
+    description: str
+    severity: str
+    created_at: str
+    signature: str = ""
+    hops: int = 0
+
+
+@app.get("/indicators")
+def list_indicators():
+    db = get_db()
+    rows = db.execute("SELECT * FROM indicators ORDER BY created_at DESC").fetchall()
+    return [dict(r) for r in rows]
+
+
+@app.post("/indicators", status_code=201)
+def create_indicator(ind: IndicatorIn):
+    from crypto import sign_event
+    from gossip import push_indicator, MAX_HOPS
+
+    ind_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+    data = {
+        "id": ind_id, "node_id": NODE_ID, "company": COMPANY,
+        "type": ind.type, "value": ind.value, "tlp": ind.tlp,
+        "description": ind.description, "severity": ind.severity,
+        "created_at": now,
+    }
+    signature = sign_event(_private_key, data)
+
+    db = get_db()
+    db.execute(
+        """INSERT INTO indicators (id, node_id, company, type, value, tlp, description, severity, created_at, signature)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (ind_id, NODE_ID, COMPANY, ind.type, ind.value, ind.tlp,
+         ind.description, ind.severity, now, signature),
+    )
+    db.commit()
+
+    data["signature"] = signature
+    data["hops"] = MAX_HOPS
+    threading.Thread(target=push_indicator, args=(data,), daemon=True).start()
+    return {"id": ind_id, "created_at": now}
+
+
+@app.get("/indicators/since/{since}")
+def indicators_since(since: str):
+    db = get_db()
+    rows = db.execute(
+        "SELECT * FROM indicators WHERE created_at > ? ORDER BY created_at", (since,)
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+@app.post("/indicators/sync", status_code=201)
+def sync_indicators(indicators: list[Indicator]):
+    from gossip import push_indicator
+    db = get_db()
+    new_count = 0
+    for ind in indicators:
+        try:
+            db.execute(
+                """INSERT INTO indicators (id, node_id, company, type, value, tlp, description, severity, created_at, signature)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (ind.id, ind.node_id, ind.company, ind.type, ind.value, ind.tlp,
+                 ind.description, ind.severity, ind.created_at, ind.signature),
+            )
+            new_count += 1
+            if ind.hops > 0:
+                threading.Thread(target=push_indicator, args=(ind.model_dump(),), daemon=True).start()
+        except Exception:
+            pass  # duplicate
+    db.commit()
+    return {"inserted": new_count}
+
+
+# ── Chat (per-event discussion) ─────────────────────────────────────
+
+
+class ChatIn(BaseModel):
+    author: str = ""
+    message: str
+
+
+class ChatMessage(BaseModel):
+    id: str
+    event_id: str
+    node_id: str
+    company: str
+    author: str
+    message: str
+    created_at: str
+    signature: str = ""
+    hops: int = 0
+
+
+@app.get("/events/{event_id}/chat")
+def get_event_chat(event_id: str):
+    db = get_db()
+    rows = db.execute(
+        "SELECT * FROM chat_messages WHERE event_id = ? ORDER BY created_at ASC",
+        (event_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+@app.post("/events/{event_id}/chat", status_code=201)
+def post_event_chat(event_id: str, msg: ChatIn):
+    from crypto import sign_event
+    from gossip import push_chat, MAX_HOPS
+
+    msg_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+    data = {
+        "id": msg_id, "event_id": event_id, "node_id": NODE_ID,
+        "company": COMPANY, "author": msg.author or COMPANY,
+        "message": msg.message, "created_at": now,
+    }
+    signature = sign_event(_private_key, data)
+
+    db = get_db()
+    db.execute(
+        """INSERT INTO chat_messages (id, event_id, node_id, company, author, message, created_at, signature)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (msg_id, event_id, NODE_ID, COMPANY, msg.author or COMPANY, msg.message, now, signature),
+    )
+    db.commit()
+
+    data["signature"] = signature
+    data["hops"] = MAX_HOPS
+    threading.Thread(target=push_chat, args=(data,), daemon=True).start()
+    return {"id": msg_id, "created_at": now}
+
+
+@app.get("/chat/since/{since}")
+def chat_since(since: str):
+    db = get_db()
+    rows = db.execute(
+        "SELECT * FROM chat_messages WHERE created_at > ? ORDER BY created_at", (since,)
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+@app.post("/chat/sync", status_code=201)
+def sync_chat(messages: list[ChatMessage]):
+    from gossip import push_chat
+    db = get_db()
+    new_count = 0
+    for m in messages:
+        try:
+            db.execute(
+                """INSERT INTO chat_messages (id, event_id, node_id, company, author, message, created_at, signature)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (m.id, m.event_id, m.node_id, m.company, m.author, m.message, m.created_at, m.signature),
+            )
+            new_count += 1
+            if m.hops > 0:
+                threading.Thread(target=push_chat, args=(m.model_dump(),), daemon=True).start()
+        except Exception:
+            pass
+    db.commit()
+    return {"inserted": new_count}
+
+
+# ── Vulnerabilities ─────────────────────────────────────────────────
+
+
+@app.get("/vulnerabilities")
+def list_vulnerabilities():
+    db = get_db()
+    rows = db.execute("SELECT * FROM vulnerabilities ORDER BY cvss_score DESC").fetchall()
+    return [dict(r) for r in rows]
+
+
+@app.get("/vulnerabilities/{vuln_id}")
+def get_vulnerability(vuln_id: str):
+    db = get_db()
+    row = db.execute("SELECT * FROM vulnerabilities WHERE id = ?", (vuln_id,)).fetchone()
+    if not row:
+        raise HTTPException(404, detail="Vulnerability not found")
+    return dict(row)
+
+
+class VulnStatusUpdate(BaseModel):
+    status: str  # open / in_progress / closed
+
+
+@app.patch("/vulnerabilities/{vuln_id}")
+def update_vulnerability_status(vuln_id: str, update: VulnStatusUpdate):
+    if update.status not in ("open", "in_progress", "closed"):
+        raise HTTPException(400, detail="Invalid status")
+    db = get_db()
+    db.execute("UPDATE vulnerabilities SET status = ? WHERE id = ?", (update.status, vuln_id))
+    db.commit()
+    return {"id": vuln_id, "status": update.status}

--- a/app/backend/static/chat.html
+++ b/app/backend/static/chat.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="no">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Nordlys — Diskusjon</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300;400;500;600;700;800&family=DM+Mono:wght@300;400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root{--void:#060912;--deep:#080e1c;--panel:#0d1528;--panel2:#111c35;--ridge:#152244;--ridge-b:#1e3468;--teal:#2dd4bf;--green:#34d399;--cyan:#22d3ee;--purple:#a78bfa;--red:#ef4444;--orange:#f97316;--yellow:#eab308;--grey:#334155;--text:#e2e8f0;--dim:#64748b;--muted:#475569;--mono:'DM Mono','Menlo',monospace;--display:'Outfit',sans-serif}
+[data-theme="light"]{--void:#f4f1eb;--deep:#e8e4db;--panel:#ffffff;--panel2:#f0ede6;--ridge:#d4d0c8;--ridge-b:#bfbab0;--teal:#0d8f64;--green:#1a8a5e;--cyan:#1a7fa3;--purple:#7c5cbf;--red:#dc2626;--orange:#ea580c;--yellow:#b8860b;--grey:#94a3b8;--text:#1a1e2a;--dim:#5c5f6a;--muted:#7c7f8a}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{font-size:clamp(14px,.3vw+13px,16px)}
+body{background:var(--void);color:var(--text);font-family:var(--mono);height:100vh;overflow:hidden}
+
+.shell{display:flex;flex-direction:column;height:100vh}
+
+.topbar{display:flex;align-items:center;gap:10px;padding:8px 20px;background:var(--panel);border-bottom:1px solid var(--ridge);flex-shrink:0;flex-wrap:wrap}
+.topbar .logo{font-family:'Bricolage Grotesque',var(--display);font-weight:800;font-size:1.3rem;background:linear-gradient(135deg,var(--teal),var(--green) 40%,var(--purple));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;text-decoration:none}
+.topbar .logo-caption{font-family:var(--mono);font-size:.55rem;color:var(--muted);letter-spacing:.1em;text-transform:uppercase}
+.topbar .sep{color:var(--muted);font-size:1.2rem}
+.topbar .page-title{font-family:var(--display);font-weight:600;font-size:1rem;color:var(--dim)}
+.topbar .spacer{flex:1}
+.topbar .back{font-size:.72rem;color:var(--teal);text-decoration:none;border:1px solid rgba(45,212,191,.3);padding:4px 10px;border-radius:4px;transition:all .15s}
+.topbar .back:hover{background:rgba(45,212,191,.08)}
+
+.main{display:flex;flex:1;overflow:hidden}
+
+/* Event list (left) */
+.event-list{width:380px;border-right:1px solid var(--ridge);display:flex;flex-direction:column;flex-shrink:0;overflow:hidden}
+.el-header{padding:10px 14px;font-size:.55rem;color:var(--muted);text-transform:uppercase;letter-spacing:.12em;border-bottom:1px solid var(--ridge);display:flex;align-items:center;gap:8px}
+.el-search{flex:1;font-family:var(--mono);font-size:.72rem;padding:5px 10px;background:var(--deep);border:1px solid var(--ridge);border-radius:4px;color:var(--text);outline:none}
+.el-search:focus{border-color:var(--teal)}
+.el-scroll{flex:1;overflow-y:auto}
+.ev-item{padding:10px 14px;border-bottom:1px solid rgba(21,34,68,.5);cursor:pointer;transition:all .15s;position:relative}
+.ev-item:hover{background:var(--panel2)}
+.ev-item.active{background:var(--panel2);border-left:3px solid var(--teal)}
+.ev-item .ev-title{font-size:.78rem;font-weight:500;margin-bottom:3px;display:flex;align-items:center;gap:6px}
+.ev-item .ev-pip{width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.ev-pip.critical{background:var(--red)}.ev-pip.high{background:var(--orange)}.ev-pip.medium{background:var(--yellow)}.ev-pip.low{background:var(--green)}
+.ev-item .ev-sub{font-size:.65rem;color:var(--muted);display:flex;gap:10px}
+.ev-item .chat-count{position:absolute;right:14px;top:50%;transform:translateY(-50%);background:rgba(45,212,191,.15);color:var(--teal);font-size:.6rem;padding:2px 7px;border-radius:10px;font-weight:600}
+
+/* Chat panel (right) */
+.chat-panel{flex:1;display:flex;flex-direction:column;overflow:hidden}
+.chat-header{padding:14px 20px;border-bottom:1px solid var(--ridge);background:var(--panel)}
+.chat-header h3{font-family:var(--display);font-weight:600;font-size:.95rem;margin-bottom:3px}
+.chat-header .ch-meta{font-size:.65rem;color:var(--muted)}
+.sev{display:inline-block;padding:1px 6px;border-radius:2px;font-size:.55rem;font-weight:600;text-transform:uppercase}
+.sev.critical{background:rgba(239,68,68,.12);color:var(--red)}
+.sev.high{background:rgba(249,115,22,.12);color:var(--orange)}
+.sev.medium{background:rgba(234,179,8,.12);color:var(--yellow)}
+.sev.low{background:rgba(52,211,153,.12);color:var(--green)}
+
+.chat-messages{flex:1;overflow-y:auto;padding:16px 20px;display:flex;flex-direction:column;gap:8px}
+.msg{max-width:80%;padding:10px 14px;border-radius:8px;font-size:.8rem;line-height:1.5;position:relative}
+.msg.them{background:var(--panel2);border:1px solid var(--ridge);align-self:flex-start;border-bottom-left-radius:2px}
+.msg.me{background:rgba(45,212,191,.08);border:1px solid rgba(45,212,191,.2);align-self:flex-end;border-bottom-right-radius:2px}
+.msg .msg-author{font-size:.6rem;color:var(--teal);font-weight:600;margin-bottom:3px;text-transform:uppercase;letter-spacing:.06em}
+.msg.them .msg-author{color:var(--purple)}
+.msg .msg-time{font-size:.55rem;color:var(--muted);margin-top:4px;text-align:right}
+
+.chat-empty{flex:1;display:flex;align-items:center;justify-content:center;color:var(--muted);font-size:.85rem}
+
+.chat-input{display:flex;gap:8px;padding:12px 20px;border-top:1px solid var(--ridge);background:var(--panel)}
+.chat-input input{flex:1;font-family:var(--mono);font-size:.8rem;padding:10px 14px;background:var(--deep);border:1px solid var(--ridge);border-radius:6px;color:var(--text);outline:none}
+.chat-input input:focus{border-color:var(--teal)}
+.chat-input button{font-family:var(--mono);font-size:.8rem;padding:10px 18px;background:rgba(45,212,191,.12);border:1px solid rgba(45,212,191,.3);border-radius:6px;color:var(--teal);cursor:pointer;font-weight:600;white-space:nowrap;transition:all .15s}
+.chat-input button:hover{background:rgba(45,212,191,.2)}
+
+.no-event{display:flex;align-items:center;justify-content:center;flex:1;color:var(--muted);font-size:.85rem;flex-direction:column;gap:8px}
+
+@media(max-width:800px){
+  .event-list{width:100%;height:40%;border-right:none;border-bottom:1px solid var(--ridge)}
+  .main{flex-direction:column}
+}
+</style>
+</head>
+<body>
+<button id="themeToggle" aria-label="Bytt tema" style="position:fixed;top:12px;right:14px;z-index:100;width:40px;height:22px;border-radius:11px;border:1px solid var(--ridge-b);background:var(--deep);cursor:pointer;padding:0;transition:background .3s"></button>
+<style>#themeToggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--teal);transition:transform .3s}[data-theme="light"] #themeToggle::after{transform:translateX(18px)}</style>
+<script>(function(){var b=document.getElementById('themeToggle'),s=localStorage.getItem('nordlys-theme');if(s)document.documentElement.setAttribute('data-theme',s);b.addEventListener('click',function(){var n=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);localStorage.setItem('nordlys-theme',n)});})()</script>
+<div class="shell">
+  <nav class="topbar">
+    <a class="logo" href="/">Nordlys</a>
+    <span class="logo-caption" style="font-family:'DM Mono','Menlo',monospace;font-size:.55rem;color:#475569;letter-spacing:.1em;text-transform:uppercase">Security Toolkit</span>
+    <span class="sep">/</span>
+    <span class="page-title">Diskusjon</span>
+    <span class="spacer"></span>
+    <a class="back" href="/">Dashboard</a>
+    <a class="back" href="/indicators/ui">IoC-er</a>
+    <a class="back" href="/vulnerabilities/ui">Sårbarheter</a>
+  </nav>
+
+  <div class="main">
+    <div class="event-list">
+      <div class="el-header">
+        Hendelser
+        <input class="el-search" id="evSearch" placeholder="Søk...">
+      </div>
+      <div class="el-scroll" id="evList"></div>
+    </div>
+
+    <div class="chat-panel" id="chatPanel">
+      <div class="no-event" id="noEvent">
+        <div>Velg en hendelse for å starte diskusjon</div>
+        <div style="font-size:.7rem;color:var(--grey)">Chat-meldinger gossipes til alle peers i meshen</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+var events = [];
+var chatCounts = {};
+var selectedEvent = null;
+var myCompany = '';
+var pollTimer = null;
+
+function esc(s){var d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+
+function loadEvents(){
+  fetch('/stats').then(function(r){return r.json();}).then(function(s){myCompany=s.company;});
+  fetch('/events').then(function(r){return r.json();}).then(function(data){
+    events=data;
+    renderEventList();
+  });
+}
+
+function renderEventList(){
+  var q=document.getElementById('evSearch').value.toLowerCase();
+  var list=document.getElementById('evList');
+  var filtered=events.filter(function(e){
+    if(!q) return true;
+    return (e.title+' '+e.company+' '+e.severity).toLowerCase().indexOf(q)>=0;
+  });
+
+  list.innerHTML=filtered.map(function(e){
+    var active=selectedEvent&&selectedEvent.id===e.id;
+    var cnt=chatCounts[e.id]||0;
+    return '<div class="ev-item'+(active?' active':'')+'" onclick="selectEvent(\''+e.id+'\')">'+
+      '<div class="ev-title"><span class="ev-pip '+e.severity+'"></span>'+esc(e.title)+'</div>'+
+      '<div class="ev-sub"><span class="sev '+e.severity+'">'+esc(e.severity)+'</span><span>'+esc(e.company)+'</span><span>'+new Date(e.created_at).toLocaleString('nb-NO',{hour:'2-digit',minute:'2-digit',day:'numeric',month:'short'})+'</span></div>'+
+      (cnt>0?'<span class="chat-count">'+cnt+'</span>':'')+
+    '</div>';
+  }).join('');
+
+  if(filtered.length===0) list.innerHTML='<div style="padding:20px;color:var(--muted);font-size:.8rem;text-align:center">Ingen hendelser ennå</div>';
+}
+
+function selectEvent(id){
+  selectedEvent=events.find(function(e){return e.id===id;});
+  if(!selectedEvent) return;
+  renderEventList();
+  renderChat();
+  loadChat();
+  if(pollTimer) clearInterval(pollTimer);
+  pollTimer=setInterval(loadChat,4000);
+}
+
+function renderChat(){
+  var panel=document.getElementById('chatPanel');
+  var e=selectedEvent;
+  panel.innerHTML=
+    '<div class="chat-header"><h3>'+esc(e.title)+'</h3><div class="ch-meta"><span class="sev '+e.severity+'">'+esc(e.severity)+'</span> '+esc(e.company)+' &middot; '+new Date(e.created_at).toLocaleString('nb-NO')+'</div></div>'+
+    '<div class="chat-messages" id="chatMessages"><div class="chat-empty">Ingen meldinger ennå. Start diskusjonen.</div></div>'+
+    '<div class="chat-input"><input id="chatInput" placeholder="Skriv melding..." onkeydown="if(event.key===\'Enter\')sendMsg()"><button onclick="sendMsg()">Send</button></div>';
+}
+
+function loadChat(){
+  if(!selectedEvent) return;
+  fetch('/events/'+selectedEvent.id+'/chat')
+    .then(function(r){return r.json();})
+    .then(function(msgs){
+      chatCounts[selectedEvent.id]=msgs.length;
+      renderEventList();
+      var container=document.getElementById('chatMessages');
+      if(!container) return;
+      if(msgs.length===0){container.innerHTML='<div class="chat-empty">Ingen meldinger ennå. Start diskusjonen.</div>';return;}
+      container.innerHTML=msgs.map(function(m){
+        var isMe=m.company===myCompany;
+        return '<div class="msg '+(isMe?'me':'them')+'">'+
+          '<div class="msg-author">'+esc(m.author||m.company)+'</div>'+
+          esc(m.message)+
+          '<div class="msg-time">'+new Date(m.created_at).toLocaleTimeString('nb-NO',{hour:'2-digit',minute:'2-digit'})+'</div>'+
+        '</div>';
+      }).join('');
+      container.scrollTop=container.scrollHeight;
+    });
+}
+
+function sendMsg(){
+  var input=document.getElementById('chatInput');
+  var msg=input.value.trim();
+  if(!msg||!selectedEvent) return;
+  input.value='';
+  fetch('/events/'+selectedEvent.id+'/chat',{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({message:msg})
+  }).then(function(){loadChat();});
+}
+
+document.getElementById('evSearch').addEventListener('input',renderEventList);
+
+// Auto-select event from URL hash
+function checkHash(){
+  var h=location.hash.replace('#','');
+  if(h && !selectedEvent) selectEvent(h);
+}
+
+loadEvents();
+setTimeout(checkHash,500);
+setInterval(function(){
+  fetch('/events').then(function(r){return r.json();}).then(function(data){
+    events=data;
+    renderEventList();
+  });
+},15000);
+</script>
+</body>
+</html>

--- a/app/backend/static/event-detail.html
+++ b/app/backend/static/event-detail.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="no">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Nordlys — Hendelse</title>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300;400;500;600;700;800&family=DM+Mono:wght@300;400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root{--void:#060912;--deep:#080e1c;--panel:#0d1528;--panel2:#111c35;--ridge:#152244;--ridge-b:#1e3468;--teal:#2dd4bf;--green:#34d399;--cyan:#22d3ee;--purple:#a78bfa;--red:#ef4444;--orange:#f97316;--yellow:#eab308;--grey:#334155;--text:#e2e8f0;--dim:#64748b;--muted:#475569;--mono:'DM Mono','Menlo',monospace;--display:'Outfit',sans-serif}
+[data-theme="light"]{--void:#f4f1eb;--deep:#e8e4db;--panel:#ffffff;--panel2:#f0ede6;--ridge:#d4d0c8;--ridge-b:#bfbab0;--teal:#0d8f64;--green:#1a8a5e;--cyan:#1a7fa3;--purple:#7c5cbf;--red:#dc2626;--orange:#ea580c;--yellow:#b8860b;--grey:#94a3b8;--text:#1a1e2a;--dim:#5c5f6a;--muted:#7c7f8a}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{font-size:clamp(14px,.3vw+13px,16px)}
+body{background:var(--void);color:var(--text);font-family:var(--mono);min-height:100vh;line-height:1.5}
+
+.shell{max-width:800px;margin:0 auto;padding:clamp(18px,2.6vw,34px) clamp(18px,3.2vw,48px);display:flex;flex-direction:column;gap:clamp(14px,1.6vw,22px)}
+
+.topbar{display:flex;align-items:center;gap:10px;padding:8px 20px;background:var(--panel);border:1px solid var(--ridge);border-radius:8px;flex-wrap:wrap}
+.topbar .logo{font-family:'Bricolage Grotesque',var(--display);font-weight:800;font-size:1.3rem;background:linear-gradient(135deg,var(--teal),var(--green) 40%,var(--purple));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;text-decoration:none}
+.topbar .sep{color:var(--muted);font-size:1.2rem}
+.topbar .page-title{font-family:var(--display);font-weight:600;font-size:1.05rem;color:var(--dim)}
+.topbar .spacer{flex:1}
+.topbar .back{font-size:.75rem;color:var(--teal);text-decoration:none;border:1px solid rgba(45,212,191,.3);padding:5px 12px;border-radius:4px;transition:all .15s}
+.topbar .back:hover{background:rgba(45,212,191,.08);border-color:var(--teal)}
+
+.card{background:var(--panel);border:1px solid var(--ridge);border-radius:8px;padding:24px;display:flex;flex-direction:column;gap:16px}
+.card h1{font-family:var(--display);font-weight:700;font-size:1.3rem}
+
+.row{display:grid;grid-template-columns:130px 1fr;gap:6px;padding:8px 0;border-bottom:1px solid rgba(21,34,68,.5);font-size:.82rem}
+.row-label{color:var(--muted);font-size:.65rem;text-transform:uppercase;letter-spacing:.08em;align-self:center}
+
+.sev{display:inline-block;padding:2px 8px;border-radius:3px;font-size:.65rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.sev.critical{background:rgba(239,68,68,.12);color:var(--red)}
+.sev.high{background:rgba(249,115,22,.12);color:var(--orange)}
+.sev.medium{background:rgba(234,179,8,.12);color:var(--yellow)}
+.sev.low{background:rgba(52,211,153,.12);color:var(--green)}
+.sev.info{background:rgba(100,116,139,.12);color:var(--dim)}
+
+.source-tag{font-size:.7rem;color:var(--dim);background:var(--deep);padding:2px 6px;border-radius:3px;display:inline-block}
+
+.desc{font-size:.85rem;color:var(--dim);line-height:1.6;padding:14px;background:var(--deep);border-radius:6px}
+
+.actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
+.actions a{font-size:.75rem;color:var(--teal);text-decoration:none;border:1px solid rgba(45,212,191,.3);padding:6px 14px;border-radius:4px;transition:all .15s}
+.actions a:hover{background:rgba(45,212,191,.08)}
+
+.loading{text-align:center;padding:40px;color:var(--muted)}
+</style>
+</head>
+<body>
+<button id="themeToggle" aria-label="Bytt tema" style="position:fixed;top:12px;right:14px;z-index:100;width:40px;height:22px;border-radius:11px;border:1px solid var(--ridge-b);background:var(--deep);cursor:pointer;padding:0;transition:background .3s"></button>
+<style>#themeToggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--teal);transition:transform .3s}[data-theme="light"] #themeToggle::after{transform:translateX(18px)}</style>
+<script>(function(){var b=document.getElementById('themeToggle'),s=localStorage.getItem('nordlys-theme');if(s)document.documentElement.setAttribute('data-theme',s);b.addEventListener('click',function(){var n=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);localStorage.setItem('nordlys-theme',n)});})()</script>
+<div class="shell">
+  <nav class="topbar">
+    <a class="logo" href="/">Nordlys</a>
+    <span class="sep">/</span>
+    <a class="back" href="/events/ui" style="border:none;padding:0;font-size:1.05rem;font-family:var(--display);font-weight:600;color:var(--dim)">Hendelser</a>
+    <span class="sep">/</span>
+    <span class="page-title" id="pageTitle">Detalj</span>
+    <span class="spacer"></span>
+    <a class="back" href="/">Dashboard</a>
+    <a class="back" href="/events/ui">Alle hendelser</a>
+  </nav>
+
+  <div id="content"><div class="loading">Laster hendelse...</div></div>
+</div>
+
+<script>
+function esc(s){var d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+
+function fmtTime(iso){
+  try{return new Date(iso).toLocaleString('nb-NO',{weekday:'short',day:'numeric',month:'short',year:'numeric',hour:'2-digit',minute:'2-digit',second:'2-digit'});}
+  catch(e){return '–';}
+}
+
+function render(e){
+  var sev = e.severity || 'info';
+  document.getElementById('pageTitle').textContent = (e.title||'Hendelse').substring(0,40);
+  document.title = 'Nordlys — ' + (e.title||'Hendelse');
+
+  var html = '<div class="card">';
+  html += '<h1>'+esc(e.title || e.event_type || '–')+'</h1>';
+  html += '<div class="row"><span class="row-label">Tidspunkt</span><span>'+fmtTime(e.created_at)+'</span></div>';
+  html += '<div class="row"><span class="row-label">Alvorlighet</span><span class="sev '+sev+'">'+esc(sev)+'</span></div>';
+  html += '<div class="row"><span class="row-label">Organisasjon</span><span>'+esc(e.company||'–')+'</span></div>';
+  html += '<div class="row"><span class="row-label">Kilde</span><span class="source-tag">'+esc(e.source||'–')+'</span></div>';
+  html += '<div class="row"><span class="row-label">Node</span><span>'+esc(e.node_id||'–')+'</span></div>';
+  if(e.scenario_id) html += '<div class="row"><span class="row-label">Scenario</span><span>'+esc(e.scenario_id)+'</span></div>';
+  if(e.external_ref) html += '<div class="row"><span class="row-label">Ekstern ref.</span><span style="word-break:break-all">'+esc(e.external_ref)+'</span></div>';
+  html += '<div class="row"><span class="row-label">Event-ID</span><span style="font-size:.7rem;word-break:break-all">'+esc(e.id||'–')+'</span></div>';
+  if(e.signature) html += '<div class="row"><span class="row-label">Signatur</span><span style="font-size:.6rem;word-break:break-all;color:var(--muted)">'+esc(e.signature)+'</span></div>';
+  if(e.description) html += '<div class="desc">'+esc(e.description)+'</div>';
+  html += '<div class="actions"><a href="/chat/ui#'+e.id+'">Diskuter hendelsen</a><a href="/events/ui">Tilbake til liste</a></div>';
+  html += '</div>';
+
+  document.getElementById('content').innerHTML = html;
+}
+
+var eventId = window.location.hash.substring(1);
+if(!eventId){
+  document.getElementById('content').innerHTML = '<div class="loading">Ingen hendelse valgt. <a href="/events/ui" style="color:var(--teal)">Gå til hendelser</a></div>';
+} else {
+  fetch('/events').then(function(r){return r.json();}).then(function(events){
+    var found = null;
+    for(var i=0;i<events.length;i++){
+      if(events[i].id === eventId){found=events[i];break;}
+    }
+    if(found) render(found);
+    else document.getElementById('content').innerHTML = '<div class="loading">Hendelse ikke funnet. <a href="/events/ui" style="color:var(--teal)">Gå til hendelser</a></div>';
+  });
+}
+</script>
+</body>
+</html>

--- a/app/backend/static/events.html
+++ b/app/backend/static/events.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<html lang="no">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Nordlys — Hendelser</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300;400;500;600;700;800&family=DM+Mono:wght@300;400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root{--void:#060912;--deep:#080e1c;--panel:#0d1528;--panel2:#111c35;--ridge:#152244;--ridge-b:#1e3468;--teal:#2dd4bf;--green:#34d399;--cyan:#22d3ee;--purple:#a78bfa;--red:#ef4444;--orange:#f97316;--yellow:#eab308;--grey:#334155;--text:#e2e8f0;--dim:#64748b;--muted:#475569;--mono:'DM Mono','Menlo',monospace;--display:'Outfit',sans-serif}
+[data-theme="light"]{--void:#f4f1eb;--deep:#e8e4db;--panel:#ffffff;--panel2:#f0ede6;--ridge:#d4d0c8;--ridge-b:#bfbab0;--teal:#0d8f64;--green:#1a8a5e;--cyan:#1a7fa3;--purple:#7c5cbf;--red:#dc2626;--orange:#ea580c;--yellow:#b8860b;--grey:#94a3b8;--text:#1a1e2a;--dim:#5c5f6a;--muted:#7c7f8a}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{font-size:clamp(14px,.3vw+13px,16px)}
+body{background:var(--void);color:var(--text);font-family:var(--mono);min-height:100vh;line-height:1.5}
+
+.shell{max-width:1700px;margin:0 auto;padding:clamp(18px,2.6vw,34px) clamp(18px,3.2vw,48px);display:flex;flex-direction:column;gap:clamp(14px,1.6vw,22px)}
+
+.topbar{display:flex;align-items:center;gap:10px;padding:8px 20px;background:var(--panel);border:1px solid var(--ridge);border-radius:8px;flex-wrap:wrap}
+.topbar .logo{font-family:'Bricolage Grotesque',var(--display);font-weight:800;font-size:1.3rem;background:linear-gradient(135deg,var(--teal),var(--green) 40%,var(--purple));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;text-decoration:none}
+.topbar .logo-caption{font-family:var(--mono);font-size:.55rem;color:var(--muted);letter-spacing:.1em;text-transform:uppercase}
+.topbar .sep{color:var(--muted);font-size:1.2rem}
+.topbar .page-title{font-family:var(--display);font-weight:600;font-size:1.05rem;color:var(--dim)}
+.topbar .spacer{flex:1}
+.topbar .back{font-size:.75rem;color:var(--teal);text-decoration:none;border:1px solid rgba(45,212,191,.3);padding:5px 12px;border-radius:4px;transition:all .15s}
+.topbar .back:hover{background:rgba(45,212,191,.08);border-color:var(--teal)}
+
+.stats{display:flex;gap:12px;flex-wrap:wrap}
+.stat{padding:10px 16px;background:var(--panel);border:1px solid var(--ridge);border-radius:6px;display:flex;align-items:center;gap:8px}
+.stat .num{font-family:var(--display);font-weight:700;font-size:1.3rem}
+.stat .lbl{font-size:.7rem;color:var(--dim);text-transform:uppercase;letter-spacing:.08em}
+.stat.crit .num{color:var(--red)}
+.stat.high .num{color:var(--orange)}
+.stat.med .num{color:var(--yellow)}
+.stat.total .num{color:var(--teal)}
+
+.controls{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+.search{flex:1;min-width:200px;font-family:var(--mono);font-size:.8rem;padding:8px 14px;background:var(--deep);border:1px solid var(--ridge);border-radius:6px;color:var(--text);outline:none;transition:border-color .2s}
+.search:focus{border-color:var(--teal)}
+.search::placeholder{color:var(--muted)}
+select{font-family:var(--mono);font-size:.75rem;padding:7px 12px;background:var(--panel);border:1px solid var(--ridge);border-radius:4px;color:var(--text);cursor:pointer;outline:none}
+select:focus{border-color:var(--teal)}
+
+.tbl-wrap{overflow-x:auto;border:1px solid var(--ridge);border-radius:8px;background:var(--panel)}
+table{width:100%;border-collapse:collapse;font-size:.78rem}
+th{text-align:left;padding:10px 14px;font-size:.6rem;color:var(--muted);text-transform:uppercase;letter-spacing:.1em;font-weight:500;border-bottom:1px solid var(--ridge);background:var(--deep);position:sticky;top:0;user-select:none}
+td{padding:10px 14px;border-bottom:1px solid rgba(21,34,68,.5);vertical-align:top}
+tr:hover{background:rgba(45,212,191,.03)}
+tr.critical{border-left:3px solid var(--red)}
+tr.high{border-left:3px solid var(--orange)}
+tr.medium{border-left:3px solid var(--yellow)}
+tr.low{border-left:3px solid var(--green)}
+tr.info{border-left:3px solid var(--grey)}
+
+.sev{display:inline-block;padding:2px 8px;border-radius:3px;font-size:.6rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.sev.critical{background:rgba(239,68,68,.12);color:var(--red)}
+.sev.high{background:rgba(249,115,22,.12);color:var(--orange)}
+.sev.medium{background:rgba(234,179,8,.12);color:var(--yellow)}
+.sev.low{background:rgba(52,211,153,.12);color:var(--green)}
+.sev.info{background:rgba(100,116,139,.12);color:var(--dim)}
+
+.source{font-size:.7rem;color:var(--dim);background:var(--deep);padding:2px 6px;border-radius:3px;display:inline-block}
+
+.empty{text-align:center;padding:40px;color:var(--muted);font-size:.85rem}
+
+/* Detail overlay */
+.detail-overlay{position:fixed;inset:0;background:rgba(6,9,18,.7);backdrop-filter:blur(4px);z-index:50;display:none;align-items:center;justify-content:center}
+.detail-overlay.open{display:flex}
+.detail-panel{width:95%;max-width:700px;max-height:85vh;overflow-y:auto;background:var(--panel);border:1px solid var(--ridge-b);border-radius:8px;padding:24px;box-shadow:0 16px 60px rgba(0,0,0,.5)}
+.det-head{display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:16px}
+.det-head h2{font-family:var(--display);font-weight:700;font-size:1.1rem;color:var(--text)}
+.det-close{background:none;border:none;color:var(--muted);font-size:1.4rem;cursor:pointer;padding:2px 8px;border-radius:4px;line-height:1}
+.det-close:hover{background:var(--ridge);color:var(--text)}
+.det-row{display:grid;grid-template-columns:120px 1fr;gap:6px;padding:6px 0;border-bottom:1px solid rgba(21,34,68,.5);font-size:.8rem}
+.det-label{color:var(--muted);font-size:.65rem;text-transform:uppercase;letter-spacing:.08em}
+.det-desc{font-size:.85rem;color:var(--dim);line-height:1.6;margin-top:12px;padding:12px;background:var(--deep);border-radius:6px}
+.chat-link{display:inline-block;margin-top:12px;font-size:.75rem;color:var(--teal);text-decoration:none;border:1px solid rgba(45,212,191,.3);padding:5px 12px;border-radius:4px;transition:all .15s}
+.chat-link:hover{background:rgba(45,212,191,.08)}
+
+@media(max-width:700px){
+  .stats{flex-direction:column}
+  .controls{flex-direction:column}
+  table{font-size:.7rem}
+  th,td{padding:8px 10px}
+}
+</style>
+</head>
+<body>
+<button id="themeToggle" aria-label="Bytt tema" style="position:fixed;top:12px;right:14px;z-index:100;width:40px;height:22px;border-radius:11px;border:1px solid var(--ridge-b);background:var(--deep);cursor:pointer;padding:0;transition:background .3s"></button>
+<style>#themeToggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--teal);transition:transform .3s}[data-theme="light"] #themeToggle::after{transform:translateX(18px)}</style>
+<script>(function(){var b=document.getElementById('themeToggle'),s=localStorage.getItem('nordlys-theme');if(s)document.documentElement.setAttribute('data-theme',s);b.addEventListener('click',function(){var n=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);localStorage.setItem('nordlys-theme',n)});})()</script>
+<div class="shell">
+  <nav class="topbar">
+    <a class="logo" href="/">Nordlys</a>
+    <span class="logo-caption">Security Toolkit</span>
+    <span class="sep">/</span>
+    <span class="page-title">Hendelser</span>
+    <span class="spacer"></span>
+    <a class="back" href="/">Dashboard</a>
+    <a class="back" href="/indicators/ui">IoC-er</a>
+    <a class="back" href="/vulnerabilities/ui">Sårbarheter</a>
+    <a class="back" href="/chat/ui">Diskusjon</a>
+  </nav>
+
+  <div class="stats" id="stats"></div>
+
+  <div class="controls">
+    <input class="search" id="search" type="text" placeholder="Søk etter tittel, kilde, beskrivelse...">
+    <select id="fSeverity"><option value="">Alle alvorligheter</option><option value="critical">Kritisk</option><option value="high">Høy</option><option value="medium">Medium</option><option value="low">Lav</option><option value="info">Info</option></select>
+    <select id="fSource"><option value="">Alle kilder</option></select>
+    <select id="fSort"><option value="newest">Nyest</option><option value="oldest">Eldst</option><option value="severity">Alvorlighet</option></select>
+  </div>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th style="width:140px">Tidspunkt</th>
+          <th style="width:80px">Alvorlighet</th>
+          <th>Tittel</th>
+          <th style="min-width:180px">Beskrivelse</th>
+          <th style="width:100px">Kilde</th>
+          <th style="width:100px">Organisasjon</th>
+        </tr>
+      </thead>
+      <tbody id="tbody"></tbody>
+    </table>
+  </div>
+  <div class="empty" id="empty" style="display:none">Ingen hendelser funnet</div>
+</div>
+
+<!-- Detail overlay -->
+<div class="detail-overlay" id="detailOverlay" onclick="if(event.target===this)closeDetail()">
+  <div class="detail-panel" id="detailPanel"></div>
+</div>
+
+<script>
+var allData = [];
+var filtered = [];
+
+function esc(s){var d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+
+var sevOrder = {critical:0, high:1, medium:2, low:3, info:4};
+
+function renderStats(){
+  var s = document.getElementById('stats');
+  var total = allData.length;
+  var crit = allData.filter(function(e){return e.severity==='critical';}).length;
+  var high = allData.filter(function(e){return e.severity==='high';}).length;
+  var med = allData.filter(function(e){return e.severity==='medium';}).length;
+  s.innerHTML =
+    '<div class="stat total"><span class="num">'+total+'</span><span class="lbl">Totalt</span></div>'+
+    '<div class="stat crit"><span class="num">'+crit+'</span><span class="lbl">Kritiske</span></div>'+
+    '<div class="stat high"><span class="num">'+high+'</span><span class="lbl">Høye</span></div>'+
+    '<div class="stat med"><span class="num">'+med+'</span><span class="lbl">Medium</span></div>';
+}
+
+function populateSources(){
+  var sources = {};
+  for(var i=0;i<allData.length;i++){
+    var src = allData[i].source || allData[i].company || '';
+    if(src) sources[src] = true;
+  }
+  var sel = document.getElementById('fSource');
+  var keys = Object.keys(sources).sort();
+  sel.innerHTML = '<option value="">Alle kilder</option>' + keys.map(function(k){
+    return '<option value="'+esc(k)+'">'+esc(k)+'</option>';
+  }).join('');
+}
+
+function applyFilters(){
+  var q = document.getElementById('search').value.toLowerCase();
+  var sev = document.getElementById('fSeverity').value;
+  var src = document.getElementById('fSource').value;
+  var sort = document.getElementById('fSort').value;
+
+  filtered = allData.filter(function(e){
+    if(sev && e.severity !== sev) return false;
+    if(src && (e.source || e.company) !== src) return false;
+    if(q){
+      var hay = ((e.title||'') +' '+ (e.description||'') +' '+ (e.source||'') +' '+ (e.company||'') +' '+ (e.node_id||'')).toLowerCase();
+      return hay.indexOf(q) >= 0;
+    }
+    return true;
+  });
+
+  if(sort==='newest') filtered.sort(function(a,b){return (b.created_at||'').localeCompare(a.created_at||'');});
+  else if(sort==='oldest') filtered.sort(function(a,b){return (a.created_at||'').localeCompare(b.created_at||'');});
+  else if(sort==='severity') filtered.sort(function(a,b){return (sevOrder[a.severity]||4) - (sevOrder[b.severity]||4);});
+
+  renderTable();
+}
+
+function fmtTime(iso){
+  try{return new Date(iso).toLocaleString('nb-NO',{day:'numeric',month:'short',hour:'2-digit',minute:'2-digit',second:'2-digit'});}
+  catch(e){return '–';}
+}
+
+function renderTable(){
+  var tbody = document.getElementById('tbody');
+  var empty = document.getElementById('empty');
+  if(filtered.length===0){tbody.innerHTML='';empty.style.display='block';return;}
+  empty.style.display='none';
+
+  tbody.innerHTML = filtered.map(function(e, i){
+    var sev = e.severity || 'info';
+    var src = e.source || '–';
+    var desc = e.description || '';
+    var shortDesc = desc.length > 90 ? desc.substring(0, 90) + '…' : desc;
+    var org = e.company || '–';
+    return '<tr class="'+sev+'" onclick="showDetail('+i+')" style="cursor:pointer">'+
+      '<td>'+fmtTime(e.created_at)+'</td>'+
+      '<td><span class="sev '+sev+'">'+esc(sev)+'</span></td>'+
+      '<td>'+esc(e.title || e.event_type || '–')+'</td>'+
+      '<td style="font-size:.72rem;color:var(--dim)">'+esc(shortDesc || '–')+'</td>'+
+      '<td><span class="source">'+esc(src)+'</span></td>'+
+      '<td style="font-size:.72rem;color:var(--dim)">'+esc(org)+'</td>'+
+    '</tr>';
+  }).join('');
+}
+
+function showDetail(idx){
+  var e = filtered[idx]; if(!e) return;
+  var p = document.getElementById('detailPanel');
+  var sev = e.severity || 'info';
+  p.innerHTML =
+    '<div class="det-head"><h2>'+esc(e.title || e.event_type || '–')+'</h2><button class="det-close" onclick="closeDetail()">&times;</button></div>'+
+    '<div class="det-row"><span class="det-label">Tidspunkt</span><span>'+fmtTime(e.created_at)+'</span></div>'+
+    '<div class="det-row"><span class="det-label">Alvorlighet</span><span class="sev '+sev+'">'+esc(sev)+'</span></div>'+
+    '<div class="det-row"><span class="det-label">Organisasjon</span><span>'+esc(e.company||'–')+'</span></div>'+
+    '<div class="det-row"><span class="det-label">Kilde</span><span class="source">'+esc(e.source||'–')+'</span></div>'+
+    '<div class="det-row"><span class="det-label">Node</span><span>'+esc(e.node_id||'–')+'</span></div>'+
+    (e.scenario_id?'<div class="det-row"><span class="det-label">Scenario</span><span>'+esc(e.scenario_id)+'</span></div>':'')+
+    (e.external_ref?'<div class="det-row"><span class="det-label">Ekstern ref.</span><span style="word-break:break-all">'+esc(e.external_ref)+'</span></div>':'')+
+    '<div class="det-row"><span class="det-label">ID</span><span style="font-size:.7rem;word-break:break-all">'+esc(e.id||'–')+'</span></div>'+
+    (e.signature?'<div class="det-row"><span class="det-label">Signatur</span><span style="font-size:.6rem;word-break:break-all;color:var(--muted)">'+esc(e.signature.substring(0,48))+'…</span></div>':'')+
+    (e.description?'<div class="det-desc">'+esc(e.description)+'</div>':'')+
+    '<a class="chat-link" href="/chat/ui#'+e.id+'">Diskuter denne hendelsen</a>';
+  document.getElementById('detailOverlay').classList.add('open');
+}
+
+function closeDetail(){document.getElementById('detailOverlay').classList.remove('open');}
+document.addEventListener('keydown',function(ev){if(ev.key==='Escape')closeDetail();});
+
+document.getElementById('search').addEventListener('input', applyFilters);
+document.getElementById('fSeverity').addEventListener('change', applyFilters);
+document.getElementById('fSource').addEventListener('change', applyFilters);
+document.getElementById('fSort').addEventListener('change', applyFilters);
+
+function loadData(){
+  fetch('/events').then(function(r){return r.json();}).then(function(data){
+    allData = data;
+    renderStats();
+    populateSources();
+    applyFilters();
+  });
+}
+loadData();
+setInterval(loadData, 10000);
+</script>
+</body>
+</html>

--- a/app/backend/static/index.html
+++ b/app/backend/static/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>STK — Security Toolkit</title>
+    <title>Nordlys — Security Toolkit</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link
       href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300;400;500;600;700;800&family=DM+Mono:wght@300;400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap"
@@ -32,6 +32,7 @@
         --mono: 'DM Mono', 'Menlo', monospace;
         --display: 'Outfit', sans-serif;
       }
+[data-theme="light"]{--void:#f4f1eb;--deep:#e8e4db;--panel:#ffffff;--panel2:#f0ede6;--ridge:#d4d0c8;--ridge-b:#bfbab0;--teal:#0d8f64;--green:#1a8a5e;--cyan:#1a7fa3;--purple:#7c5cbf;--red:#dc2626;--orange:#ea580c;--yellow:#b8860b;--grey:#94a3b8;--text:#1a1e2a;--dim:#5c5f6a;--muted:#7c7f8a}
       *,
       *::before,
       *::after {
@@ -144,8 +145,8 @@
       .header {
         display: flex;
         align-items: center;
-        gap: clamp(16px, 2vw, 30px);
-        padding: clamp(20px, 2.2vw, 34px) clamp(20px, 2.8vw, 36px);
+        gap: clamp(12px, 1.4vw, 20px);
+        padding: clamp(8px, 0.8vw, 12px) clamp(16px, 2vw, 28px);
         background: linear-gradient(135deg, var(--panel) 0%, var(--deep) 100%);
         border: 1px solid var(--ridge);
         border-radius: 10px;
@@ -162,22 +163,29 @@
       .brand {
         display: flex;
         flex-direction: column;
-        gap: 8px;
+        gap: 2px;
       }
       .brand-row {
         display: flex;
         align-items: baseline;
-        gap: 14px;
+        gap: 8px;
       }
       .logo {
         font-family: 'Bricolage Grotesque', var(--display);
         font-weight: 800;
-        font-size: clamp(2.6rem, 3.6vw, 3.8rem);
+        font-size: clamp(1.3rem, 1.8vw, 1.8rem);
         letter-spacing: -0.03em;
         background: linear-gradient(135deg, var(--teal), var(--green) 40%, var(--purple));
         -webkit-background-clip: text;
         -webkit-text-fill-color: transparent;
         background-clip: text;
+      }
+      .logo-caption {
+        font-family: var(--mono);
+        font-size: clamp(0.55rem, 0.2vw + 0.5rem, 0.68rem);
+        color: var(--muted);
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
       }
       .brand-sub {
         font-family: var(--display);
@@ -274,17 +282,17 @@
       /* ── Counters strip ─────────────────────────────────── */
       .counters {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(245px, 1fr));
-        gap: clamp(12px, 1.5vw, 20px);
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: clamp(8px, 1vw, 14px);
       }
       .counter {
-        padding: clamp(18px, 1.7vw, 26px) clamp(18px, 1.9vw, 28px);
+        padding: clamp(10px, 1vw, 14px) clamp(12px, 1.2vw, 18px);
         background: var(--panel);
         border: 1px solid var(--ridge);
-        border-radius: 10px;
+        border-radius: 8px;
         display: flex;
         flex-direction: column;
-        gap: 10px;
+        gap: 4px;
         position: relative;
         overflow: hidden;
       }
@@ -310,7 +318,7 @@
         --accent: var(--purple);
       }
       .c-label {
-        font-size: clamp(0.68rem, 0.2vw + 0.62rem, 0.82rem);
+        font-size: clamp(0.58rem, 0.15vw + 0.54rem, 0.7rem);
         letter-spacing: 0.12em;
         text-transform: uppercase;
         color: var(--dim);
@@ -323,7 +331,7 @@
         line-height: 1;
       }
       .c-sub {
-        font-size: clamp(0.74rem, 0.2vw + 0.7rem, 0.88rem);
+        font-size: clamp(0.62rem, 0.15vw + 0.58rem, 0.75rem);
         color: var(--muted);
         letter-spacing: 0.04em;
       }
@@ -331,51 +339,146 @@
         color: var(--dim);
         font-weight: 500;
       }
+      a.counter {
+        transition: all 0.15s ease;
+      }
+      a.counter:hover {
+        border-color: var(--ridge-b);
+        background: var(--panel2);
+        transform: translateY(-1px);
+      }
+
+      /* ── Live feed ──────────────────────────────────── */
+      .feed {
+        background: var(--panel);
+        border: 1px solid var(--ridge);
+        border-radius: 10px;
+        overflow: hidden;
+        flex: 1;
+        min-height: 260px;
+        display: flex;
+        flex-direction: column;
+      }
+      .feed-hdr {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 14px 20px;
+        border-bottom: 1px solid var(--ridge);
+        font-family: var(--display);
+        font-size: 0.82rem;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--dim);
+      }
+      .feed-hdr .live-dot {
+        width: 8px; height: 8px;
+        border-radius: 50%;
+        background: var(--red);
+        box-shadow: 0 0 8px var(--red);
+        animation: pulse-r 1.6s ease-out infinite;
+      }
+      .feed-list {
+        flex: 1;
+        overflow-y: auto;
+        padding: 0;
+        list-style: none;
+        scrollbar-width: thin;
+        scrollbar-color: var(--ridge) transparent;
+      }
+      .feed-list::-webkit-scrollbar { width: 5px; }
+      .feed-list::-webkit-scrollbar-thumb { background: var(--ridge); border-radius: 3px; }
+      .feed-item {
+        display: grid;
+        grid-template-columns: 68px 1fr auto;
+        gap: 10px;
+        align-items: start;
+        padding: 10px 20px;
+        border-bottom: 1px solid rgba(21,34,68,0.5);
+        font-size: 0.82rem;
+        animation: feed-in 0.35s ease-out;
+      }
+      .feed-item:hover { background: rgba(45,212,191,0.03); }
+      @keyframes feed-in {
+        from { opacity: 0; transform: translateY(-6px); }
+        to   { opacity: 1; transform: translateY(0); }
+      }
+      .feed-time {
+        color: var(--muted);
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+      }
+      .feed-body {
+        color: var(--text);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .feed-body .feed-src {
+        color: var(--teal);
+        font-weight: 500;
+      }
+      .feed-sev {
+        font-size: 0.7rem;
+        padding: 2px 8px;
+        border-radius: 3px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        white-space: nowrap;
+      }
+      .feed-sev.critical { background: rgba(239,68,68,0.18); color: var(--red); }
+      .feed-sev.high     { background: rgba(234,179,8,0.16); color: var(--yellow); }
+      .feed-sev.medium   { background: rgba(34,211,238,0.12); color: var(--cyan); }
+      .feed-sev.low      { background: rgba(52,211,153,0.12); color: var(--green); }
+      .feed-sev.info     { background: rgba(100,116,139,0.14); color: var(--dim); }
+      .feed-empty {
+        padding: 40px 20px;
+        text-align: center;
+        color: var(--muted);
+        font-style: italic;
+      }
 
       /* ── Mesh footer ─────────────────────────────────── */
       .mesh {
         display: flex;
         align-items: center;
-        gap: clamp(14px, 1.8vw, 26px);
-        padding: clamp(18px, 1.9vw, 28px) clamp(18px, 2.5vw, 34px);
-        background: linear-gradient(135deg, var(--panel2) 0%, var(--panel) 100%);
+        padding: 6px 12px;
+        background: var(--panel);
         border: 1px solid var(--ridge);
-        border-radius: 10px;
+        border-radius: 6px;
         flex-wrap: wrap;
         margin-top: auto;
       }
       .mesh-actions {
         display: flex;
-        gap: 8px;
+        gap: 4px;
         flex-wrap: wrap;
       }
       .mesh-link {
-        font-family: var(--display);
-        font-size: clamp(0.78rem, 0.2vw + 0.74rem, 0.9rem);
-        font-weight: 500;
-        letter-spacing: 0.06em;
-        text-transform: uppercase;
-        color: var(--text);
-        background: rgba(34, 211, 238, 0.08);
-        border: 1px solid rgba(34, 211, 238, 0.3);
-        padding: 10px 16px;
-        border-radius: 6px;
+        font-family: var(--mono);
+        font-size: 0.62rem;
+        font-weight: 400;
+        letter-spacing: 0.04em;
+        color: var(--dim);
+        background: none;
+        border: none;
+        padding: 3px 8px;
+        border-radius: 3px;
         text-decoration: none;
         transition: all 0.15s ease;
       }
       .mesh-link:hover {
-        background: rgba(34, 211, 238, 0.16);
-        border-color: var(--cyan);
+        background: rgba(34, 211, 238, 0.08);
         color: var(--cyan);
       }
       .mesh-link.secondary {
-        background: transparent;
-        border-color: var(--ridge);
-        color: var(--dim);
+        color: var(--muted);
       }
       .mesh-link.secondary:hover {
-        border-color: var(--ridge-b);
-        color: var(--text);
+        color: var(--dim);
+        background: rgba(100,116,139,0.08);
       }
 
       /* ── Loading state ──────────────────────────────── */
@@ -414,6 +517,9 @@
     </style>
   </head>
   <body>
+<button id="themeToggle" aria-label="Bytt tema" style="position:fixed;top:12px;right:14px;z-index:100;width:40px;height:22px;border-radius:11px;border:1px solid var(--ridge-b);background:var(--deep);cursor:pointer;padding:0;transition:background .3s"></button>
+<style>#themeToggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--teal);transition:transform .3s}[data-theme="light"] #themeToggle::after{transform:translateX(18px)}</style>
+<script>(function(){var b=document.getElementById('themeToggle'),s=localStorage.getItem('nordlys-theme');if(s)document.documentElement.setAttribute('data-theme',s);b.addEventListener('click',function(){var n=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);localStorage.setItem('nordlys-theme',n)});})()</script>
     <div class="aurora">
       <div class="aurora__blob aurora__blob--a"></div>
       <div class="aurora__blob aurora__blob--b"></div>
@@ -427,55 +533,307 @@
         <div class="brand">
           <div class="brand-row">
             <span class="logo">Nordlys</span>
+            <span class="logo-caption">Security Toolkit</span>
           </div>
           <div class="brand-meta">
-            <b>Glitrenett</b>
-            · <b>glitrenett-01</b> · <span class="role-pill peer">peer</span>
+            <b id="hdr-company">…</b>
+            · <b id="hdr-node">…</b> · <span id="hdr-role" class="role-pill peer">…</span>
           </div>
         </div>
         <div class="hdr-spacer"></div>
         <div class="hdr-block">
-          <div class="hdr-status"><span class="dot"></span><span>Online</span></div>
-          <div class="brand-meta"><b>4/5 peers</b> · <b>1,248 events</b></div>
+          <div class="hdr-status" id="hdr-status"><span class="dot"></span><span id="hdr-status-text">…</span></div>
+          <div class="brand-meta"><b id="hdr-peers">…</b> peers · <b id="hdr-events-total">…</b> hendelser totalt</div>
         </div>
       </header>
 
       <!-- Counters -->
       <section class="counters" id="counters">
-        <div class="counter" data-accent="cyan">
+        <a class="counter" data-accent="cyan" href="/topology" style="text-decoration:none;color:inherit">
           <span class="c-label">Peers online</span>
-          <span class="c-value">4</span>
-          <span class="c-sub">av <b>5</b> registrert i meshen</span>
-        </div>
-        <div class="counter" data-accent="green">
-          <span class="c-label">Events siste 24t</span>
-          <span class="c-value">186</span>
-          <span class="c-sub"><b>12</b> kritiske / høy alvorlighet</span>
-        </div>
-        <div class="counter" data-accent="red">
-          <span class="c-label">Indicators (IoC)</span>
-          <span class="c-value">73</span>
-          <span class="c-sub"><b>9</b> TLP RED · <b>21</b> AMBER</span>
-        </div>
-        <div class="counter" data-accent="purple">
-          <span class="c-label">Chat</span>
-          <span class="c-value">6</span>
-          <span class="c-sub">koordineres i Chat</span>
-        </div>
+          <span class="c-value" id="c-peers-online">–</span>
+          <span class="c-sub">av <b id="c-peers-total">–</b> registrert · <b id="c-adoption-pct">–%</b> av ~375 aktører</span>
+        </a>
+        <a class="counter" data-accent="green" href="/events/ui" style="text-decoration:none;color:inherit">
+          <span class="c-label">Hendelser siste 24t</span>
+          <span class="c-value" id="c-events-24h">–</span>
+          <span class="c-sub"><b id="c-events-crit">–</b> kritiske / høy alvorlighet</span>
+        </a>
+        <a class="counter" data-accent="red" href="/indicators/ui" style="text-decoration:none;color:inherit">
+          <span class="c-label">Indikatorer (IoC)</span>
+          <span class="c-value" id="c-ioc-total">–</span>
+          <span class="c-sub"><b id="c-ioc-red">–</b> TLP RED · <b id="c-ioc-amber">–</b> AMBER</span>
+        </a>
+        <a class="counter" data-accent="purple" href="/vulnerabilities/ui" style="text-decoration:none;color:inherit">
+          <span class="c-label">Sårbarheter</span>
+          <span class="c-value" id="c-vuln-open">–</span>
+          <span class="c-sub"><b id="c-vuln-crit">–</b> kritiske åpne</span>
+        </a>
+        <a class="counter" data-accent="green" href="/events/ui" style="text-decoration:none;color:inherit">
+          <span class="c-label">Åpne hendelser</span>
+          <span class="c-value" id="c-incidents">–</span>
+          <span class="c-sub" id="c-events-all">– hendelser totalt i noden</span>
+        </a>
+      </section>
+
+      <!-- Live event feed -->
+      <section class="feed" id="feed">
+        <div class="feed-hdr"><span class="live-dot"></span> Hendelser</div>
+        <ul class="feed-list" id="feed-list">
+          <li class="feed-empty">Laster hendelser …</li>
+        </ul>
       </section>
 
       <!-- Mesh footer -->
       <section class="mesh">
         <div class="mesh-actions">
           <a class="mesh-link" href="/topology">Mesh-kart</a>
+          <a class="mesh-link" href="/events/ui">Hendelser</a>
+          <a class="mesh-link" href="/vulnerabilities/ui">Sårbarheter</a>
+          <a class="mesh-link" href="/indicators/ui">IoC-er</a>
+          <a class="mesh-link" href="/chat/ui">Diskusjon</a>
           <a class="mesh-link" href="/node">Detalj-visning</a>
           <a class="mesh-link secondary" href="/topology/debug" target="_blank">Gossip-debug</a>
           <a class="mesh-link secondary" href="/identity" target="_blank">Identiteter</a>
           <a class="mesh-link secondary" href="/peers" target="_blank">Peers</a>
-          <a class="mesh-link secondary" href="/events" target="_blank">Events JSON</a>
+          <a class="mesh-link secondary" href="/events" target="_blank">Hendelser JSON</a>
           <a class="mesh-link secondary" href="/.well-known/stk" target="_blank">.well-known</a>
         </div>
       </section>
     </div>
+
+    <script>
+      /* ── Audio alerts (Web Audio API) ── */
+      var audioCtx = null;
+      var audioUnlocked = false;
+      var myNodeId = null;
+      var firstPoll = true;
+
+      function getAudioCtx() {
+        if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        return audioCtx;
+      }
+
+      function playTone(freq, duration, count, gap) {
+        if (!audioUnlocked) return;
+        var ctx = getAudioCtx();
+        if (ctx.state === 'suspended') {
+          ctx.resume().then(function() { playTone(freq, duration, count, gap); });
+          return;
+        }
+        count = count || 1;
+        gap = gap || 0.12;
+        for (var i = 0; i < count; i++) {
+          var start = ctx.currentTime + i * (duration + gap);
+          var osc = ctx.createOscillator();
+          var gain = ctx.createGain();
+          osc.connect(gain);
+          gain.connect(ctx.destination);
+          osc.frequency.value = freq;
+          osc.type = 'sine';
+          gain.gain.setValueAtTime(0.22, start);
+          gain.gain.exponentialRampToValueAtTime(0.001, start + duration);
+          osc.start(start);
+          osc.stop(start + duration);
+        }
+      }
+
+      function alertSound(severity) {
+        switch ((severity || '').toLowerCase()) {
+          case 'critical':
+            playTone(880, 0.12, 4, 0.08);
+            break;
+          case 'high':
+            playTone(660, 0.15, 2, 0.12);
+            break;
+          case 'medium':
+            playTone(520, 0.2, 1);
+            break;
+          case 'low':
+            playTone(400, 0.25, 1);
+            break;
+          // info: ingen lyd
+        }
+      }
+
+      // Unlock audio on any user interaction
+      function unlockAudio() {
+        if (audioUnlocked) return;
+        try {
+          var ctx = getAudioCtx();
+          ctx.resume().then(function() {
+            audioUnlocked = true;
+            console.log('[Nordlys] Audio unlocked, state:', ctx.state);
+            // Play a short test blip to confirm
+            var osc = ctx.createOscillator();
+            var g = ctx.createGain();
+            osc.connect(g);
+            g.connect(ctx.destination);
+            osc.frequency.value = 440;
+            g.gain.setValueAtTime(0.1, ctx.currentTime);
+            g.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.08);
+            osc.start();
+            osc.stop(ctx.currentTime + 0.08);
+          });
+        } catch(e) {
+          console.error('[Nordlys] Audio unlock failed:', e);
+        }
+      }
+      document.addEventListener('click', unlockAudio);
+      document.addEventListener('keydown', unlockAudio);
+      document.addEventListener('touchstart', unlockAudio);
+
+      function set(id, text) {
+        var el = document.getElementById(id);
+        if (el) el.textContent = text;
+      }
+
+      function applyStats(s) {
+        myNodeId = s.node_id || null;
+        set('hdr-company', s.company || '–');
+        set('hdr-node', s.node_id || '–');
+        set('hdr-peers', s.peers.online);
+        set('hdr-events-total', s.events.total);
+
+        var rolePill = document.getElementById('hdr-role');
+        if (rolePill) {
+          rolePill.textContent = s.role || '–';
+          rolePill.className = 'role-pill ' + (s.role === 'kraftcert' ? 'kraftcert' : 'peer');
+        }
+
+        set('c-peers-online', s.peers.online);
+        set('c-peers-total', s.peers.total);
+        set('c-events-24h', s.events.last_24h);
+        set('c-events-crit', s.events.critical_24h);
+        set('c-ioc-total', s.indicators.total);
+        set('c-ioc-red', s.indicators.tlp_red);
+        set('c-ioc-amber', s.indicators.tlp_amber);
+        set('c-incidents', s.incidents.open);
+        set('c-vuln-open', s.vulnerabilities.open);
+        set('c-vuln-crit', s.vulnerabilities.critical);
+
+        var eventsAll = document.getElementById('c-events-all');
+        if (eventsAll) eventsAll.textContent = s.events.total + ' hendelser totalt i noden';
+
+        var total = s.peers.total || 0;
+        var pct = Math.round((total / 375) * 100 * 10) / 10;
+        set('c-adoption-pct', pct + '%');
+      }
+
+      function setOnline(online) {
+        var statusEl = document.getElementById('hdr-status');
+        var statusText = document.getElementById('hdr-status-text');
+        if (!statusEl) return;
+        if (online) {
+          statusEl.className = 'hdr-status';
+          if (statusText) statusText.textContent = 'Online';
+        } else {
+          statusEl.className = 'hdr-status offline';
+          if (statusText) statusText.textContent = 'Offline';
+        }
+      }
+
+      function poll() {
+        fetch('/stats')
+          .then(function(r) { return r.ok ? r.json() : Promise.reject(r.status); })
+          .then(function(data) {
+            setOnline(true);
+            applyStats(data);
+          })
+          .catch(function() {
+            setOnline(false);
+          });
+      }
+
+      poll();
+      setInterval(poll, 10000);
+
+      /* ── Live feed ── */
+      var feedKnown = {};
+      var feedMax = 80;
+
+      function sevClass(s) {
+        if (!s) return 'info';
+        var l = s.toLowerCase();
+        if (l === 'critical') return 'critical';
+        if (l === 'high') return 'high';
+        if (l === 'medium') return 'medium';
+        if (l === 'low') return 'low';
+        return 'info';
+      }
+
+      function fmtTime(iso) {
+        try { var d = new Date(iso); return d.toLocaleTimeString('nb-NO', {hour:'2-digit',minute:'2-digit',second:'2-digit'}); }
+        catch(e) { return '–'; }
+      }
+
+      function renderFeedItem(ev) {
+        var li = document.createElement('li');
+        li.className = 'feed-item';
+        li.style.cursor = 'pointer';
+        li.onclick = function() { window.location.href = '/events/ui/detail#' + ev.id; };
+        var src = ev.company || ev.source || ev.node_id || '?';
+        var desc = ev.title || ev.description || ev.event_type || '–';
+        var sev = ev.severity || 'info';
+        li.innerHTML =
+          '<span class="feed-time">' + fmtTime(ev.created_at) + '</span>' +
+          '<span class="feed-body"><span class="feed-src">' + src + '</span> ' + desc + '</span>' +
+          '<span class="feed-sev ' + sevClass(sev) + '">' + sev + '</span>';
+        return li;
+      }
+
+      function pollFeed() {
+        fetch('/events')
+          .then(function(r) { return r.ok ? r.json() : Promise.reject(r.status); })
+          .then(function(events) {
+            var list = document.getElementById('feed-list');
+            var newItems = [];
+            for (var i = 0; i < events.length; i++) {
+              var ev = events[i];
+              if (!feedKnown[ev.id]) {
+                feedKnown[ev.id] = true;
+                newItems.push(ev);
+              }
+            }
+            if (newItems.length === 0 && Object.keys(feedKnown).length === 0) {
+              list.innerHTML = '<li class="feed-empty">Ingen hendelser ennå</li>';
+              firstPoll = false;
+              return;
+            }
+            // Play sound for highest-severity new event not from this node
+            if (!firstPoll && newItems.length > 0) {
+              var dominated = null;
+              var sevRank = {critical:0, high:1, medium:2, low:3, info:4};
+              for (var k = 0; k < newItems.length; k++) {
+                var nev = newItems[k];
+                if (nev.node_id === myNodeId) continue;
+                if (nev.event_type === 'chat') continue;
+                var s = (nev.severity || 'info').toLowerCase();
+                if (dominated === null || (sevRank[s] || 4) < (sevRank[dominated] || 4)) {
+                  dominated = s;
+                }
+              }
+              if (dominated && dominated !== 'info') alertSound(dominated);
+            }
+            firstPoll = false;
+            // Remove empty placeholder
+            var empty = list.querySelector('.feed-empty');
+            if (empty) empty.remove();
+            // Prepend new items (newest first — events already sorted DESC)
+            for (var j = 0; j < newItems.length; j++) {
+              var item = renderFeedItem(newItems[j]);
+              list.insertBefore(item, list.firstChild);
+            }
+            // Trim old items
+            while (list.children.length > feedMax) {
+              list.removeChild(list.lastChild);
+            }
+          })
+          .catch(function() {});
+      }
+
+      pollFeed();
+      setInterval(pollFeed, 5000);
+    </script>
   </body>
 </html>

--- a/app/backend/static/indicators.html
+++ b/app/backend/static/indicators.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="no">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Nordlys — Indikatorer (IoC)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300;400;500;600;700;800&family=DM+Mono:wght@300;400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root{--void:#060912;--deep:#080e1c;--panel:#0d1528;--panel2:#111c35;--ridge:#152244;--ridge-b:#1e3468;--teal:#2dd4bf;--green:#34d399;--cyan:#22d3ee;--purple:#a78bfa;--red:#ef4444;--orange:#f97316;--yellow:#eab308;--grey:#334155;--text:#e2e8f0;--dim:#64748b;--muted:#475569;--mono:'DM Mono','Menlo',monospace;--display:'Outfit',sans-serif}
+[data-theme="light"]{--void:#f4f1eb;--deep:#e8e4db;--panel:#ffffff;--panel2:#f0ede6;--ridge:#d4d0c8;--ridge-b:#bfbab0;--teal:#0d8f64;--green:#1a8a5e;--cyan:#1a7fa3;--purple:#7c5cbf;--red:#dc2626;--orange:#ea580c;--yellow:#b8860b;--grey:#94a3b8;--text:#1a1e2a;--dim:#5c5f6a;--muted:#7c7f8a}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{font-size:clamp(14px,.3vw+13px,16px)}
+body{background:var(--void);color:var(--text);font-family:var(--mono);min-height:100vh;line-height:1.5}
+
+.shell{max-width:1700px;margin:0 auto;padding:clamp(18px,2.6vw,34px) clamp(18px,3.2vw,48px);display:flex;flex-direction:column;gap:clamp(14px,1.6vw,22px)}
+
+.topbar{display:flex;align-items:center;gap:10px;padding:8px 20px;background:var(--panel);border:1px solid var(--ridge);border-radius:8px;flex-wrap:wrap}
+.topbar .logo{font-family:'Bricolage Grotesque',var(--display);font-weight:800;font-size:1.3rem;background:linear-gradient(135deg,var(--teal),var(--green) 40%,var(--purple));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;text-decoration:none}
+.topbar .logo-caption{font-family:var(--mono);font-size:.55rem;color:var(--muted);letter-spacing:.1em;text-transform:uppercase}
+.topbar .sep{color:var(--muted);font-size:1.2rem}
+.topbar .page-title{font-family:var(--display);font-weight:600;font-size:1.05rem;color:var(--dim)}
+.topbar .spacer{flex:1}
+.topbar .back{font-size:.75rem;color:var(--teal);text-decoration:none;border:1px solid rgba(45,212,191,.3);padding:5px 12px;border-radius:4px;transition:all .15s}
+.topbar .back:hover{background:rgba(45,212,191,.08);border-color:var(--teal)}
+
+.stats{display:flex;gap:12px;flex-wrap:wrap}
+.stat{padding:10px 16px;background:var(--panel);border:1px solid var(--ridge);border-radius:6px;display:flex;align-items:center;gap:8px}
+.stat .num{font-family:var(--display);font-weight:700;font-size:1.3rem}
+.stat .lbl{font-size:.7rem;color:var(--dim);text-transform:uppercase;letter-spacing:.08em}
+.stat.red .num{color:var(--red)}.stat.amber .num{color:var(--orange)}.stat.green .num{color:var(--green)}
+
+.controls{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+.search{flex:1;min-width:200px;font-family:var(--mono);font-size:.8rem;padding:8px 14px;background:var(--deep);border:1px solid var(--ridge);border-radius:6px;color:var(--text);outline:none;transition:border-color .2s}
+.search:focus{border-color:var(--teal)}
+.search::placeholder{color:var(--muted)}
+select{font-family:var(--mono);font-size:.75rem;padding:7px 12px;background:var(--panel);border:1px solid var(--ridge);border-radius:4px;color:var(--text);cursor:pointer;outline:none}
+.btn{font-family:var(--mono);font-size:.75rem;padding:7px 14px;border:1px solid rgba(45,212,191,.3);border-radius:4px;background:rgba(45,212,191,.08);color:var(--teal);cursor:pointer;transition:all .15s;white-space:nowrap}
+.btn:hover{background:rgba(45,212,191,.16);border-color:var(--teal)}
+
+/* Cards */
+.ioc-grid{display:flex;flex-direction:column;gap:6px}
+.ioc-card{display:grid;grid-template-columns:80px 1fr 70px 80px 120px;gap:14px;align-items:center;padding:12px 16px;background:var(--panel);border:1px solid var(--ridge);border-radius:6px;transition:all .15s}
+.ioc-card:hover{background:var(--panel2);border-color:var(--ridge-b)}
+.ioc-type{font-size:.6rem;text-transform:uppercase;letter-spacing:.1em;color:var(--dim);font-weight:600}
+.ioc-value{font-size:.85rem;font-weight:500;word-break:break-all}
+.tlp{display:inline-block;padding:2px 8px;border-radius:3px;font-size:.6rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.tlp.RED{background:rgba(239,68,68,.12);color:var(--red)}
+.tlp.AMBER{background:rgba(249,115,22,.12);color:var(--orange)}
+.tlp.GREEN{background:rgba(52,211,153,.12);color:var(--green)}
+.tlp.WHITE{background:rgba(226,232,240,.08);color:var(--dim)}
+.sev{display:inline-block;padding:2px 8px;border-radius:3px;font-size:.6rem;font-weight:600;text-transform:uppercase}
+.sev.critical{background:rgba(239,68,68,.12);color:var(--red)}
+.sev.high{background:rgba(249,115,22,.12);color:var(--orange)}
+.sev.medium{background:rgba(234,179,8,.12);color:var(--yellow)}
+.sev.low{background:rgba(52,211,153,.12);color:var(--green)}
+.ioc-meta{font-size:.65rem;color:var(--muted)}
+.ioc-desc{font-size:.72rem;color:var(--dim);margin-top:4px}
+
+.empty{text-align:center;padding:40px;color:var(--muted);font-size:.85rem}
+
+/* Create form overlay */
+.form-overlay{position:fixed;inset:0;background:rgba(6,9,18,.7);backdrop-filter:blur(4px);z-index:50;display:none;align-items:center;justify-content:center}
+.form-overlay.open{display:flex}
+.form-panel{width:95%;max-width:520px;background:var(--panel);border:1px solid var(--ridge-b);border-radius:8px;padding:24px;box-shadow:0 16px 60px rgba(0,0,0,.5)}
+.form-panel h2{font-family:var(--display);font-weight:700;font-size:1rem;margin-bottom:16px;display:flex;justify-content:space-between;align-items:center}
+.form-panel .det-close{background:none;border:none;color:var(--muted);font-size:1.3rem;cursor:pointer;padding:2px 8px;border-radius:4px}
+.form-panel .det-close:hover{background:var(--ridge);color:var(--text)}
+.field{margin-bottom:12px}
+.field label{display:block;font-size:.6rem;color:var(--muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:4px}
+.field input,.field select,.field textarea{width:100%;font-family:var(--mono);font-size:.8rem;padding:8px 12px;background:var(--deep);border:1px solid var(--ridge);border-radius:4px;color:var(--text);outline:none}
+.field input:focus,.field select:focus,.field textarea:focus{border-color:var(--teal)}
+.field textarea{resize:vertical;min-height:60px}
+.form-row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+.submit-btn{font-family:var(--mono);font-size:.8rem;padding:10px 20px;border:none;border-radius:6px;background:linear-gradient(135deg,rgba(45,212,191,.2),rgba(52,211,153,.2));color:var(--teal);cursor:pointer;width:100%;font-weight:600;transition:all .15s}
+.submit-btn:hover{background:linear-gradient(135deg,rgba(45,212,191,.3),rgba(52,211,153,.3))}
+
+@media(max-width:900px){
+  .ioc-card{grid-template-columns:1fr;gap:6px}
+}
+</style>
+</head>
+<body>
+<button id="themeToggle" aria-label="Bytt tema" style="position:fixed;top:12px;right:14px;z-index:100;width:40px;height:22px;border-radius:11px;border:1px solid var(--ridge-b);background:var(--deep);cursor:pointer;padding:0;transition:background .3s"></button>
+<style>#themeToggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--teal);transition:transform .3s}[data-theme="light"] #themeToggle::after{transform:translateX(18px)}</style>
+<script>(function(){var b=document.getElementById('themeToggle'),s=localStorage.getItem('nordlys-theme');if(s)document.documentElement.setAttribute('data-theme',s);b.addEventListener('click',function(){var n=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);localStorage.setItem('nordlys-theme',n)});})()</script>
+<div class="shell">
+  <nav class="topbar">
+    <a class="logo" href="/">Nordlys</a>
+    <span class="logo-caption">Security Toolkit</span>
+    <span class="sep">/</span>
+    <span class="page-title">Indikatorer (IoC)</span>
+    <span class="spacer"></span>
+    <a class="back" href="/">Dashboard</a>
+    <a class="back" href="/vulnerabilities/ui">Sårbarheter</a>
+  </nav>
+
+  <div class="stats" id="stats"></div>
+
+  <div class="controls">
+    <input class="search" id="search" type="text" placeholder="Søk etter IP, domene, hash, TTP, beskrivelse...">
+    <select id="fType"><option value="">Alle typer</option><option value="ip">IP</option><option value="domain">Domene</option><option value="hash">Hash</option><option value="ttp">TTP</option></select>
+    <select id="fTlp"><option value="">Alle TLP</option><option value="RED">RED</option><option value="AMBER">AMBER</option><option value="GREEN">GREEN</option><option value="WHITE">WHITE</option></select>
+    <select id="fSeverity"><option value="">Alle alvorligheter</option><option value="critical">Kritisk</option><option value="high">Høy</option><option value="medium">Medium</option><option value="low">Lav</option></select>
+    <button class="btn" onclick="openForm()">+ Ny IoC</button>
+  </div>
+
+  <div class="ioc-grid" id="grid"></div>
+  <div class="empty" id="empty" style="display:none">Ingen treff</div>
+</div>
+
+<!-- Create form -->
+<div class="form-overlay" id="formOverlay" onclick="if(event.target===this)closeForm()">
+  <div class="form-panel">
+    <h2>Ny Indicator (IoC) <button class="det-close" onclick="closeForm()">&times;</button></h2>
+    <form id="createForm" onsubmit="return submitIoc(event)">
+      <div class="form-row">
+        <div class="field"><label>Type</label><select id="nType"><option value="ip">IP</option><option value="domain">Domene</option><option value="hash">Hash</option><option value="ttp">TTP</option></select></div>
+        <div class="field"><label>TLP</label><select id="nTlp"><option value="RED">RED</option><option value="AMBER" selected>AMBER</option><option value="GREEN">GREEN</option><option value="WHITE">WHITE</option></select></div>
+      </div>
+      <div class="field"><label>Verdi</label><input id="nValue" required placeholder="f.eks. 185.220.101.34 eller T1190"></div>
+      <div class="form-row">
+        <div class="field"><label>Alvorlighet</label><select id="nSev"><option value="critical">Kritisk</option><option value="high" selected>Hoy</option><option value="medium">Medium</option><option value="low">Lav</option></select></div>
+      </div>
+      <div class="field"><label>Beskrivelse</label><textarea id="nDesc" placeholder="Kontekst, kilde, observasjon..."></textarea></div>
+      <button class="submit-btn" type="submit">Publiser IoC til meshen</button>
+    </form>
+  </div>
+</div>
+
+<script>
+var allData = [];
+
+function esc(s){var d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+
+function renderStats(){
+  var s=document.getElementById('stats');
+  var total=allData.length;
+  var red=allData.filter(function(i){return i.tlp==='RED';}).length;
+  var amber=allData.filter(function(i){return i.tlp==='AMBER';}).length;
+  var green=allData.filter(function(i){return i.tlp==='GREEN';}).length;
+  s.innerHTML=
+    '<div class="stat"><span class="num">'+total+'</span><span class="lbl">Totalt</span></div>'+
+    '<div class="stat red"><span class="num">'+red+'</span><span class="lbl">TLP RED</span></div>'+
+    '<div class="stat amber"><span class="num">'+amber+'</span><span class="lbl">TLP AMBER</span></div>'+
+    '<div class="stat green"><span class="num">'+green+'</span><span class="lbl">TLP GREEN</span></div>';
+}
+
+function applyFilters(){
+  var q=document.getElementById('search').value.toLowerCase();
+  var ft=document.getElementById('fType').value;
+  var fl=document.getElementById('fTlp').value;
+  var fs=document.getElementById('fSeverity').value;
+
+  var filtered=allData.filter(function(i){
+    if(ft && i.type!==ft) return false;
+    if(fl && i.tlp!==fl) return false;
+    if(fs && i.severity!==fs) return false;
+    if(q){
+      var hay=(i.value+' '+i.type+' '+i.tlp+' '+i.description+' '+i.company).toLowerCase();
+      return hay.indexOf(q)>=0;
+    }
+    return true;
+  });
+
+  var grid=document.getElementById('grid');
+  var empty=document.getElementById('empty');
+  if(filtered.length===0){grid.innerHTML='';empty.style.display='block';return;}
+  empty.style.display='none';
+
+  grid.innerHTML=filtered.map(function(i){
+    return '<div class="ioc-card">'+
+      '<span class="ioc-type">'+esc(i.type)+'</span>'+
+      '<div><span class="ioc-value">'+esc(i.value)+'</span>'+
+        (i.description?'<div class="ioc-desc">'+esc(i.description)+'</div>':'')+
+        '<div class="ioc-meta">'+esc(i.company)+' &middot; '+new Date(i.created_at).toLocaleString('nb-NO')+'</div>'+
+      '</div>'+
+      '<span class="tlp '+i.tlp+'">TLP:'+i.tlp+'</span>'+
+      '<span class="sev '+i.severity+'">'+esc(i.severity)+'</span>'+
+      '<span class="ioc-meta" style="text-align:right">'+esc(i.node_id)+'</span>'+
+    '</div>';
+  }).join('');
+}
+
+function openForm(){document.getElementById('formOverlay').classList.add('open');}
+function closeForm(){document.getElementById('formOverlay').classList.remove('open');}
+document.addEventListener('keydown',function(e){if(e.key==='Escape')closeForm();});
+
+function submitIoc(e){
+  e.preventDefault();
+  var body={
+    type:document.getElementById('nType').value,
+    value:document.getElementById('nValue').value,
+    tlp:document.getElementById('nTlp').value,
+    severity:document.getElementById('nSev').value,
+    description:document.getElementById('nDesc').value,
+  };
+  fetch('/indicators',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)})
+    .then(function(){closeForm();loadData();});
+  return false;
+}
+
+document.getElementById('search').addEventListener('input',applyFilters);
+document.getElementById('fType').addEventListener('change',applyFilters);
+document.getElementById('fTlp').addEventListener('change',applyFilters);
+document.getElementById('fSeverity').addEventListener('change',applyFilters);
+
+function loadData(){
+  fetch('/indicators').then(function(r){return r.json();}).then(function(data){
+    allData=data;
+    renderStats();
+    applyFilters();
+  });
+}
+loadData();
+setInterval(loadData,15000);
+</script>
+</body>
+</html>

--- a/app/backend/static/node.html
+++ b/app/backend/static/node.html
@@ -30,6 +30,7 @@
   --mono: 'DM Mono', 'Menlo', monospace;
   --display: 'Outfit', sans-serif;
 }
+[data-theme="light"]{--void:#f4f1eb;--deep:#e8e4db;--panel:#ffffff;--panel2:#f0ede6;--ridge:#d4d0c8;--ridge-b:#bfbab0;--teal:#0d8f64;--green:#1a8a5e;--cyan:#1a7fa3;--purple:#7c5cbf;--red:#dc2626;--orange:#ea580c;--yellow:#b8860b;--grey:#94a3b8;--text:#1a1e2a;--dim:#5c5f6a;--muted:#7c7f8a}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html{font-size:14px}
 body{background:var(--void);color:var(--text);font-family:var(--mono);min-height:100vh;line-height:1.4}
@@ -206,13 +207,16 @@ body::after{content:'';position:fixed;inset:0;background:repeating-linear-gradie
 </style>
 </head>
 <body>
+<button id="themeToggle" aria-label="Bytt tema" style="position:fixed;top:12px;right:14px;z-index:100;width:40px;height:22px;border-radius:11px;border:1px solid var(--ridge-b);background:var(--deep);cursor:pointer;padding:0;transition:background .3s"></button>
+<style>#themeToggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--teal);transition:transform .3s}[data-theme="light"] #themeToggle::after{transform:translateX(18px)}</style>
+<script>(function(){var b=document.getElementById('themeToggle'),s=localStorage.getItem('nordlys-theme');if(s)document.documentElement.setAttribute('data-theme',s);b.addEventListener('click',function(){var n=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);localStorage.setItem('nordlys-theme',n)});})()</script>
 <div class="shell">
 
 <!-- ── Header ────────────────────────────────── -->
 <header class="header">
   <div class="brand">
     <div class="brand-row">
-      <span class="logo">STK</span>
+      <a class="logo" href="/" style="text-decoration:none;cursor:pointer">Nordlys</a>
       <span class="brand-sep">/</span>
       <span class="brand-company" id="brandCompany">…</span>
     </div>

--- a/app/backend/static/topology-debug.html
+++ b/app/backend/static/topology-debug.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>STK — Nettverkstopologi</title>
+<title>Nordlys — Nettverkstopologi</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
@@ -26,6 +26,7 @@
   --font-display: 'Outfit', sans-serif;
   --font-mono: 'DM Mono', 'Menlo', monospace;
 }
+[data-theme="light"]{--void:#f4f1eb;--deep:#e8e4db;--panel:#ffffff;--panel2:#f0ede6;--ridge:#d4d0c8;--ridge-b:#bfbab0;--teal:#0d8f64;--green:#1a8a5e;--cyan:#1a7fa3;--purple:#7c5cbf;--red:#dc2626;--orange:#ea580c;--yellow:#b8860b;--grey:#94a3b8;--text:#1a1e2a;--dim:#5c5f6a;--muted:#7c7f8a}
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -334,9 +335,12 @@ canvas:active { cursor: grabbing; }
 </style>
 </head>
 <body>
+<button id="themeToggle" aria-label="Bytt tema" style="position:fixed;top:12px;right:14px;z-index:100;width:40px;height:22px;border-radius:11px;border:1px solid var(--ridge-b);background:var(--deep);cursor:pointer;padding:0;transition:background .3s"></button>
+<style>#themeToggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--teal);transition:transform .3s}[data-theme="light"] #themeToggle::after{transform:translateX(18px)}</style>
+<script>(function(){var b=document.getElementById('themeToggle'),s=localStorage.getItem('nordlys-theme');if(s)document.documentElement.setAttribute('data-theme',s);b.addEventListener('click',function(){var n=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);localStorage.setItem('nordlys-theme',n)});})()</script>
 
 <div class="hud">
-  <div class="hud-title">STK</div>
+  <div class="hud-title">Nordlys</div>
   <div class="hud-sub">nettverkstopologi</div>
 </div>
 

--- a/app/backend/static/topology.html
+++ b/app/backend/static/topology.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>STK — Situasjonsforst&aring;else</title>
+<title>Nordlys — Situasjonsforst&aring;else</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
@@ -30,6 +30,7 @@
   --mono: 'DM Mono', 'Menlo', monospace;
   --display: 'Outfit', sans-serif;
 }
+[data-theme="light"]{--void:#f4f1eb;--deep:#e8e4db;--panel:#ffffff;--panel2:#f0ede6;--ridge:#d4d0c8;--ridge-b:#bfbab0;--teal:#0d8f64;--green:#1a8a5e;--cyan:#1a7fa3;--purple:#7c5cbf;--red:#dc2626;--orange:#ea580c;--yellow:#b8860b;--grey:#94a3b8;--text:#1a1e2a;--dim:#5c5f6a;--muted:#7c7f8a}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html{font-size:14px}
 body{background:var(--void);color:var(--text);font-family:var(--mono);overflow:hidden;height:100vh}
@@ -173,15 +174,19 @@ canvas:active{cursor:grabbing}
 </style>
 </head>
 <body>
+<button id="themeToggle" aria-label="Bytt tema" style="position:fixed;top:12px;right:14px;z-index:100;width:40px;height:22px;border-radius:11px;border:1px solid var(--ridge-b);background:var(--deep);cursor:pointer;padding:0;transition:background .3s"></button>
+<style>#themeToggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--teal);transition:transform .3s}[data-theme="light"] #themeToggle::after{transform:translateX(18px)}</style>
+<script>(function(){var b=document.getElementById('themeToggle'),s=localStorage.getItem('nordlys-theme');if(s)document.documentElement.setAttribute('data-theme',s);b.addEventListener('click',function(){var n=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);localStorage.setItem('nordlys-theme',n)});})()</script>
 <div class="shell">
   <header class="header">
-    <div class="logo">STK</div>
+    <a class="logo" href="/" style="text-decoration:none;cursor:pointer">Nordlys</a>
     <div class="logo-sub">situasjonsforst&aring;else</div>
     <div class="hdr-spacer"></div>
     <div class="hdr-stat" id="hdrStat"><span class="pulse"></span><span class="hdr-count" id="hdrCount">&mdash;</span> peers</div>
     <div class="clock" id="clock">--:--:--</div>
     <button class="sim-btn" onclick="simulateEvent()">Simuler hendelse</button>
     <button class="help-btn" onclick="openHelp()">Hjelp</button>
+    <a class="sim-btn" href="/" style="text-decoration:none">Dashboard</a>
   </header>
   <div class="alert" id="alert"><div class="alert-icon">!</div><div id="alertBody"></div></div>
   <div class="main">
@@ -283,7 +288,7 @@ canvas:active{cursor:grabbing}
 
 <script>
 // ── Config ─────────────────────────────────────
-const SEED = new URLSearchParams(location.search).get('seed') || 'http://localhost:8000';
+const SEED = new URLSearchParams(location.search).get('seed') || location.origin;
 const POLL = 3500;
 
 // ── State ──────────────────────────────────────

--- a/app/backend/static/vulnerabilities.html
+++ b/app/backend/static/vulnerabilities.html
@@ -1,0 +1,257 @@
+<!doctype html>
+<html lang="no">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Nordlys — Sårbarheter</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300;400;500;600;700;800&family=DM+Mono:wght@300;400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root{--void:#060912;--deep:#080e1c;--panel:#0d1528;--panel2:#111c35;--ridge:#152244;--ridge-b:#1e3468;--teal:#2dd4bf;--green:#34d399;--cyan:#22d3ee;--purple:#a78bfa;--red:#ef4444;--orange:#f97316;--yellow:#eab308;--grey:#334155;--text:#e2e8f0;--dim:#64748b;--muted:#475569;--mono:'DM Mono','Menlo',monospace;--display:'Outfit',sans-serif}
+[data-theme="light"]{--void:#f4f1eb;--deep:#e8e4db;--panel:#ffffff;--panel2:#f0ede6;--ridge:#d4d0c8;--ridge-b:#bfbab0;--teal:#0d8f64;--green:#1a8a5e;--cyan:#1a7fa3;--purple:#7c5cbf;--red:#dc2626;--orange:#ea580c;--yellow:#b8860b;--grey:#94a3b8;--text:#1a1e2a;--dim:#5c5f6a;--muted:#7c7f8a}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{font-size:clamp(14px,.3vw+13px,16px)}
+body{background:var(--void);color:var(--text);font-family:var(--mono);min-height:100vh;line-height:1.5}
+
+.shell{max-width:1700px;margin:0 auto;padding:clamp(18px,2.6vw,34px) clamp(18px,3.2vw,48px);display:flex;flex-direction:column;gap:clamp(14px,1.6vw,22px)}
+
+/* Header bar */
+.topbar{display:flex;align-items:center;gap:10px;padding:8px 20px;background:var(--panel);border:1px solid var(--ridge);border-radius:8px;flex-wrap:wrap}
+.topbar .logo{font-family:'Bricolage Grotesque',var(--display);font-weight:800;font-size:1.3rem;background:linear-gradient(135deg,var(--teal),var(--green) 40%,var(--purple));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;text-decoration:none}
+.topbar .logo-caption{font-family:var(--mono);font-size:.55rem;color:var(--muted);letter-spacing:.1em;text-transform:uppercase}
+.topbar .sep{color:var(--muted);font-size:1.2rem}
+.topbar .page-title{font-family:var(--display);font-weight:600;font-size:1.05rem;color:var(--dim)}
+.topbar .spacer{flex:1}
+.topbar .back{font-size:.75rem;color:var(--teal);text-decoration:none;border:1px solid rgba(45,212,191,.3);padding:5px 12px;border-radius:4px;transition:all .15s}
+.topbar .back:hover{background:rgba(45,212,191,.08);border-color:var(--teal)}
+
+/* Stats strip */
+.stats{display:flex;gap:12px;flex-wrap:wrap}
+.stat{padding:10px 16px;background:var(--panel);border:1px solid var(--ridge);border-radius:6px;display:flex;align-items:center;gap:8px}
+.stat .num{font-family:var(--display);font-weight:700;font-size:1.3rem}
+.stat .lbl{font-size:.7rem;color:var(--dim);text-transform:uppercase;letter-spacing:.08em}
+.stat.crit .num{color:var(--red)}
+.stat.high .num{color:var(--orange)}
+.stat.open .num{color:var(--yellow)}
+.stat.closed .num{color:var(--green)}
+
+/* Controls */
+.controls{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+.search{flex:1;min-width:200px;font-family:var(--mono);font-size:.8rem;padding:8px 14px;background:var(--deep);border:1px solid var(--ridge);border-radius:6px;color:var(--text);outline:none;transition:border-color .2s}
+.search:focus{border-color:var(--teal)}
+.search::placeholder{color:var(--muted)}
+select{font-family:var(--mono);font-size:.75rem;padding:7px 12px;background:var(--panel);border:1px solid var(--ridge);border-radius:4px;color:var(--text);cursor:pointer;outline:none}
+select:focus{border-color:var(--teal)}
+
+/* Table */
+.tbl-wrap{overflow-x:auto;border:1px solid var(--ridge);border-radius:8px;background:var(--panel)}
+table{width:100%;border-collapse:collapse;font-size:.78rem}
+th{text-align:left;padding:10px 14px;font-size:.6rem;color:var(--muted);text-transform:uppercase;letter-spacing:.1em;font-weight:500;border-bottom:1px solid var(--ridge);background:var(--deep);position:sticky;top:0;cursor:pointer;user-select:none}
+th:hover{color:var(--text)}
+th .arrow{font-size:.55rem;margin-left:4px;opacity:.4}
+th.active .arrow{opacity:1;color:var(--teal)}
+td{padding:10px 14px;border-bottom:1px solid rgba(21,34,68,.5);vertical-align:top}
+tr:hover{background:rgba(45,212,191,.03)}
+tr.critical{border-left:3px solid var(--red)}
+tr.high{border-left:3px solid var(--orange)}
+tr.medium{border-left:3px solid var(--yellow)}
+tr.low{border-left:3px solid var(--green)}
+
+/* Badges */
+.sev{display:inline-block;padding:2px 8px;border-radius:3px;font-size:.6rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.sev.critical{background:rgba(239,68,68,.12);color:var(--red)}
+.sev.high{background:rgba(249,115,22,.12);color:var(--orange)}
+.sev.medium{background:rgba(234,179,8,.12);color:var(--yellow)}
+.sev.low{background:rgba(52,211,153,.12);color:var(--green)}
+
+.cvss{font-family:var(--display);font-weight:700;font-size:.85rem}
+.cvss.c9{color:var(--red)}.cvss.c7{color:var(--orange)}.cvss.c4{color:var(--yellow)}.cvss.c0{color:var(--green)}
+
+.status-pill{font-size:.6rem;padding:2px 8px;border-radius:3px;text-transform:uppercase;letter-spacing:.06em;cursor:pointer;border:none;font-family:var(--mono)}
+.status-pill.open{background:rgba(234,179,8,.12);color:var(--yellow)}
+.status-pill.in_progress{background:rgba(34,211,238,.12);color:var(--cyan)}
+.status-pill.closed{background:rgba(52,211,153,.12);color:var(--green)}
+
+.asset{font-size:.7rem;color:var(--dim);background:var(--deep);padding:2px 6px;border-radius:3px;display:inline-block}
+
+.empty{text-align:center;padding:40px;color:var(--muted);font-size:.85rem}
+
+/* Detail panel */
+.detail-overlay{position:fixed;inset:0;background:rgba(6,9,18,.7);backdrop-filter:blur(4px);z-index:50;display:none;align-items:center;justify-content:center}
+.detail-overlay.open{display:flex}
+.detail-panel{width:95%;max-width:700px;max-height:85vh;overflow-y:auto;background:var(--panel);border:1px solid var(--ridge-b);border-radius:8px;padding:24px;box-shadow:0 16px 60px rgba(0,0,0,.5)}
+.det-head{display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:16px}
+.det-head h2{font-family:var(--display);font-weight:700;font-size:1.1rem;color:var(--text)}
+.det-close{background:none;border:none;color:var(--muted);font-size:1.4rem;cursor:pointer;padding:2px 8px;border-radius:4px;line-height:1}
+.det-close:hover{background:var(--ridge);color:var(--text)}
+.det-row{display:grid;grid-template-columns:120px 1fr;gap:6px;padding:6px 0;border-bottom:1px solid rgba(21,34,68,.5);font-size:.8rem}
+.det-label{color:var(--muted);font-size:.65rem;text-transform:uppercase;letter-spacing:.08em}
+.det-desc{font-size:.85rem;color:var(--dim);line-height:1.6;margin-top:12px;padding:12px;background:var(--deep);border-radius:6px}
+
+@media(max-width:700px){
+  .stats{flex-direction:column}
+  .controls{flex-direction:column}
+  table{font-size:.7rem}
+  th,td{padding:8px 10px}
+}
+</style>
+</head>
+<body>
+<button id="themeToggle" aria-label="Bytt tema" style="position:fixed;top:12px;right:14px;z-index:100;width:40px;height:22px;border-radius:11px;border:1px solid var(--ridge-b);background:var(--deep);cursor:pointer;padding:0;transition:background .3s"></button>
+<style>#themeToggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--teal);transition:transform .3s}[data-theme="light"] #themeToggle::after{transform:translateX(18px)}</style>
+<script>(function(){var b=document.getElementById('themeToggle'),s=localStorage.getItem('nordlys-theme');if(s)document.documentElement.setAttribute('data-theme',s);b.addEventListener('click',function(){var n=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);localStorage.setItem('nordlys-theme',n)});})()</script>
+<div class="shell">
+  <nav class="topbar">
+    <a class="logo" href="/">Nordlys</a>
+    <span class="logo-caption">Security Toolkit</span>
+    <span class="sep">/</span>
+    <span class="page-title">Sårbarheter</span>
+    <span class="spacer"></span>
+    <a class="back" href="/">Dashboard</a>
+    <a class="back" href="/indicators/ui">IoC-er</a>
+  </nav>
+
+  <div class="stats" id="stats"></div>
+
+  <div class="controls">
+    <input class="search" id="search" type="text" placeholder="Søk etter CVE, tittel, asset, beskrivelse...">
+    <select id="fSeverity"><option value="">Alle alvorligheter</option><option value="critical">Kritisk</option><option value="high">Høy</option><option value="medium">Medium</option><option value="low">Lav</option></select>
+    <select id="fStatus"><option value="">Alle statuser</option><option value="open">Åpen</option><option value="in_progress">Under arbeid</option><option value="closed">Lukket</option></select>
+    <select id="fSort"><option value="cvss_desc">CVSS høyest</option><option value="cvss_asc">CVSS lavest</option><option value="newest">Nyest</option><option value="oldest">Eldst</option><option value="cve">CVE-ID</option></select>
+  </div>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th style="width:110px">CVE-ID</th>
+          <th style="width:60px">CVSS</th>
+          <th style="width:80px">Alvorlighet</th>
+          <th>Tittel</th>
+          <th style="width:140px">Asset</th>
+          <th style="width:100px">Status</th>
+        </tr>
+      </thead>
+      <tbody id="tbody"></tbody>
+    </table>
+  </div>
+  <div class="empty" id="empty" style="display:none">Ingen treff</div>
+</div>
+
+<!-- Detail overlay -->
+<div class="detail-overlay" id="detailOverlay" onclick="if(event.target===this)closeDetail()">
+  <div class="detail-panel" id="detailPanel"></div>
+</div>
+
+<script>
+var allData = [];
+var filtered = [];
+
+function esc(s){var d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+
+function cvssClass(v){return v>=9?'c9':v>=7?'c7':v>=4?'c4':'c0';}
+
+function renderStats(){
+  var s = document.getElementById('stats');
+  var total = allData.length;
+  var open = allData.filter(function(v){return v.status==='open';}).length;
+  var crit = allData.filter(function(v){return v.severity==='critical'&&v.status==='open';}).length;
+  var high = allData.filter(function(v){return v.severity==='high'&&v.status==='open';}).length;
+  var closed = allData.filter(function(v){return v.status==='closed';}).length;
+  s.innerHTML =
+    '<div class="stat open"><span class="num">'+open+'</span><span class="lbl">Åpne</span></div>'+
+    '<div class="stat crit"><span class="num">'+crit+'</span><span class="lbl">Kritiske</span></div>'+
+    '<div class="stat high"><span class="num">'+high+'</span><span class="lbl">Høye</span></div>'+
+    '<div class="stat closed"><span class="num">'+closed+'</span><span class="lbl">Lukket</span></div>'+
+    '<div class="stat"><span class="num">'+total+'</span><span class="lbl">Totalt</span></div>';
+}
+
+function applyFilters(){
+  var q = document.getElementById('search').value.toLowerCase();
+  var sev = document.getElementById('fSeverity').value;
+  var st = document.getElementById('fStatus').value;
+  var sort = document.getElementById('fSort').value;
+
+  filtered = allData.filter(function(v){
+    if(sev && v.severity !== sev) return false;
+    if(st && v.status !== st) return false;
+    if(q){
+      var hay = (v.cve_id+' '+v.title+' '+v.asset+' '+v.description).toLowerCase();
+      return hay.indexOf(q) >= 0;
+    }
+    return true;
+  });
+
+  if(sort==='cvss_desc') filtered.sort(function(a,b){return b.cvss_score-a.cvss_score;});
+  else if(sort==='cvss_asc') filtered.sort(function(a,b){return a.cvss_score-b.cvss_score;});
+  else if(sort==='newest') filtered.sort(function(a,b){return b.created_at.localeCompare(a.created_at);});
+  else if(sort==='oldest') filtered.sort(function(a,b){return a.created_at.localeCompare(b.created_at);});
+  else if(sort==='cve') filtered.sort(function(a,b){return a.cve_id.localeCompare(b.cve_id);});
+
+  renderTable();
+}
+
+function renderTable(){
+  var tbody = document.getElementById('tbody');
+  var empty = document.getElementById('empty');
+  if(filtered.length===0){tbody.innerHTML='';empty.style.display='block';return;}
+  empty.style.display='none';
+
+  tbody.innerHTML = filtered.map(function(v, i){
+    return '<tr class="'+v.severity+'" onclick="showDetail('+i+')" style="cursor:pointer">'+
+      '<td><b>'+esc(v.cve_id)+'</b></td>'+
+      '<td><span class="cvss '+cvssClass(v.cvss_score)+'">'+v.cvss_score.toFixed(1)+'</span></td>'+
+      '<td><span class="sev '+v.severity+'">'+esc(v.severity)+'</span></td>'+
+      '<td>'+esc(v.title)+'</td>'+
+      '<td><span class="asset">'+esc(v.asset)+'</span></td>'+
+      '<td><button class="status-pill '+v.status+'" onclick="event.stopPropagation();cycleStatus(\''+v.id+'\',\''+v.status+'\')">'+statusLabel(v.status)+'</button></td>'+
+    '</tr>';
+  }).join('');
+}
+
+function statusLabel(s){
+  return s==='open'?'Åpen':s==='in_progress'?'Under arbeid':'Lukket';
+}
+
+function cycleStatus(id, current){
+  var next = current==='open'?'in_progress':current==='in_progress'?'closed':'open';
+  fetch('/vulnerabilities/'+id, {method:'PATCH', headers:{'Content-Type':'application/json'}, body:JSON.stringify({status:next})})
+    .then(function(){
+      for(var i=0;i<allData.length;i++) if(allData[i].id===id) allData[i].status=next;
+      renderStats();
+      applyFilters();
+    });
+}
+
+function showDetail(idx){
+  var v = filtered[idx]; if(!v) return;
+  var p = document.getElementById('detailPanel');
+  p.innerHTML =
+    '<div class="det-head"><h2>'+esc(v.cve_id)+' — '+esc(v.title)+'</h2><button class="det-close" onclick="closeDetail()">&times;</button></div>'+
+    '<div class="det-row"><span class="det-label">CVSS</span><span class="cvss '+cvssClass(v.cvss_score)+'">'+v.cvss_score.toFixed(1)+'</span></div>'+
+    '<div class="det-row"><span class="det-label">Alvorlighet</span><span class="sev '+v.severity+'">'+esc(v.severity)+'</span></div>'+
+    '<div class="det-row"><span class="det-label">Asset</span><span class="asset">'+esc(v.asset)+'</span></div>'+
+    '<div class="det-row"><span class="det-label">Status</span><button class="status-pill '+v.status+'" onclick="cycleStatus(\''+v.id+'\',\''+v.status+'\');showDetail('+idx+')">'+statusLabel(v.status)+'</button></div>'+
+    '<div class="det-row"><span class="det-label">Registrert</span><span>'+new Date(v.created_at).toLocaleString('nb-NO')+'</span></div>'+
+    '<div class="det-desc">'+esc(v.description)+'</div>';
+  document.getElementById('detailOverlay').classList.add('open');
+}
+
+function closeDetail(){document.getElementById('detailOverlay').classList.remove('open');}
+document.addEventListener('keydown',function(e){if(e.key==='Escape')closeDetail();});
+
+document.getElementById('search').addEventListener('input', applyFilters);
+document.getElementById('fSeverity').addEventListener('change', applyFilters);
+document.getElementById('fStatus').addEventListener('change', applyFilters);
+document.getElementById('fSort').addEventListener('change', applyFilters);
+
+fetch('/vulnerabilities')
+  .then(function(r){return r.json();})
+  .then(function(data){
+    allData = data;
+    renderStats();
+    applyFilters();
+  });
+</script>
+</body>
+</html>

--- a/app/varde/default.conf.template
+++ b/app/varde/default.conf.template
@@ -3,11 +3,13 @@ server {
     server_name _;
 
     location / {
-        proxy_pass ${UPSTREAM_URL};
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_http_version 1.1;
-        proxy_set_header Connection "";
+        proxy_pass          ${UPSTREAM_URL};
+        proxy_ssl_server_name on;
+        proxy_ssl_verify    off;
+        proxy_set_header    Host $proxy_host;
+        proxy_set_header    X-Real-IP $remote_addr;
+        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version  1.1;
+        proxy_set_header    Connection "";
     }
 }

--- a/stage/style-kit.html
+++ b/stage/style-kit.html
@@ -50,6 +50,31 @@
   --t-mono:    1rem;
 }
 
+/* ── Light mode ────────────────────────────── */
+[data-theme="light"] {
+  --bg:        #f4f1eb;          /* warm parchment — body background */
+  --bg-2:      #e8e4db;          /* raised surface */
+
+  --fg:        #1a1e2a;          /* deep ink — primary text */
+  --fg-dim:    #5c5f6a;          /* secondary text */
+
+  --aurora-1:  #1a9e72;          /* mint — darker for contrast on light */
+  --aurora-2:  #2b7ea3;          /* arctic — darker */
+  --aurora-3:  #9a8530;          /* lichen — darker */
+
+  --aurora-1-soft: #3dc99a;
+  --aurora-2-soft: #4eaad0;
+  --aurora-3-soft: #c4b85e;
+
+  --line:      rgba(26,30,42,0.12);
+  --line-hi:   rgba(26,30,42,0.25);
+}
+[data-theme="light"] .aurora__blob { mix-blend-mode: multiply; }
+[data-theme="light"] .aurora__blob--a { opacity: 0.12; }
+[data-theme="light"] .aurora__blob--b { opacity: 0.10; }
+[data-theme="light"] .aurora__blob--c { opacity: 0.06; }
+[data-theme="light"] .grain { opacity: 0.03; mix-blend-mode: multiply; }
+
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html, body {
   background: var(--bg);
@@ -64,6 +89,25 @@ body { min-height: 100vh; padding: 5rem 4rem 6rem; max-width: 1400px; margin: 0 
 ::-webkit-scrollbar { width: 10px; }
 ::-webkit-scrollbar-track { background: var(--bg); }
 ::-webkit-scrollbar-thumb { background: var(--line-hi); border-radius: 10px; }
+
+/* ── Theme toggle ──────────────────────────── */
+.theme-toggle {
+  position: fixed; top: 1.2rem; right: 1.4rem; z-index: 100;
+  width: 44px; height: 24px; border-radius: 12px;
+  border: 1px solid var(--line-hi); background: var(--bg-2);
+  cursor: pointer; padding: 0; transition: background 0.3s, border-color 0.3s;
+}
+.theme-toggle::after {
+  content: ''; position: absolute; top: 3px; left: 3px;
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--aurora-1); transition: transform 0.3s;
+}
+[data-theme="light"] .theme-toggle::after { transform: translateX(20px); }
+.theme-toggle-label {
+  position: fixed; top: 2.8rem; right: 1.4rem; z-index: 100;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.6rem;
+  letter-spacing: 0.15em; text-transform: uppercase; color: var(--fg-dim);
+}
 
 /* ── Atmosphere (same as stage) ────────────────────────── */
 .aurora { position: fixed; inset: 0; z-index: 0; pointer-events: none; overflow: hidden; }
@@ -200,7 +244,7 @@ body { min-height: 100vh; padding: 5rem 4rem 6rem; max-width: 1400px; margin: 0 
 .code {
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.85rem; line-height: 1.65;
-  background: #02050b;
+  background: var(--bg);
   border: 1px solid var(--line);
   color: var(--fg);
   padding: 1.4rem 1.6rem;
@@ -319,6 +363,9 @@ body { min-height: 100vh; padding: 5rem 4rem 6rem; max-width: 1400px; margin: 0 
 </head>
 <body>
 
+<button class="theme-toggle" id="themeToggle" aria-label="Bytt tema"></button>
+<span class="theme-toggle-label" id="themeLabel">dark</span>
+
 <div class="aurora">
   <div class="aurora__blob aurora__blob--a"></div>
   <div class="aurora__blob aurora__blob--b"></div>
@@ -339,6 +386,7 @@ body { min-height: 100vh; padding: 5rem 4rem 6rem; max-width: 1400px; margin: 0 
     <a href="#atmosphere">03 — Atmosfære</a>
     <a href="#components">04 — Komponenter</a>
     <a href="#usage">05 — Bruk</a>
+    <a href="#theme">06 — Tema</a>
   </nav>
 </header>
 
@@ -704,12 +752,108 @@ body { min-height: 100vh; padding: 5rem 4rem 6rem; max-width: 1400px; margin: 0 
   </ul>
 </section>
 
+<!-- ════════════ 06 · DARK / LIGHT MODE ════════════ -->
+<section class="kit-section" id="theme">
+  <div class="kit-section__num">06 · Tema</div>
+  <h2 class="kit-section__title">Dark / Light mode</h2>
+  <p class="kit-section__desc">
+    Tema styres av <code style="color:var(--aurora-1);font-family:'JetBrains Mono',monospace">data-theme</code>-attributtet
+    på <code style="color:var(--aurora-1);font-family:'JetBrains Mono',monospace">&lt;html&gt;</code>.
+    Dark er standard. Valget lagres i <code style="color:var(--aurora-1);font-family:'JetBrains Mono',monospace">localStorage</code>
+    under nøkkelen <code style="color:var(--aurora-1);font-family:'JetBrains Mono',monospace">nordlys-theme</code>.
+    Alle CSS-variabler overskrives automatisk — ingen endringer trengs i komponentene.
+  </p>
+
+  <h3 class="t-mono-sm" style="margin-bottom:1rem">Light mode-variabler</h3>
+  <div class="code" data-lang="CSS" data-copy='[data-theme="light"] {
+  --bg:        #f4f1eb;
+  --bg-2:      #e8e4db;
+  --fg:        #1a1e2a;
+  --fg-dim:    #5c5f6a;
+  --aurora-1:  #1a9e72;
+  --aurora-2:  #2b7ea3;
+  --aurora-3:  #9a8530;
+  --aurora-1-soft: #3dc99a;
+  --aurora-2-soft: #4eaad0;
+  --aurora-3-soft: #c4b85e;
+  --line:      rgba(26,30,42,0.12);
+  --line-hi:   rgba(26,30,42,0.25);
+}
+[data-theme="light"] .aurora__blob { mix-blend-mode: multiply; }
+[data-theme="light"] .grain { opacity: 0.03; mix-blend-mode: multiply; }'>[data-theme=<span class="val">"light"</span>] {
+  <span class="var">--bg</span>:        <span class="val">#f4f1eb</span>;        <span class="com">/* warm parchment */</span>
+  <span class="var">--bg-2</span>:      <span class="val">#e8e4db</span>;        <span class="com">/* raised */</span>
+  <span class="var">--fg</span>:        <span class="val">#1a1e2a</span>;        <span class="com">/* deep ink */</span>
+  <span class="var">--fg-dim</span>:    <span class="val">#5c5f6a</span>;        <span class="com">/* muted */</span>
+  <span class="var">--aurora-1</span>:  <span class="val">#1a9e72</span>;        <span class="com">/* mint (darker) */</span>
+  <span class="var">--aurora-2</span>:  <span class="val">#2b7ea3</span>;        <span class="com">/* arctic (darker) */</span>
+  <span class="var">--aurora-3</span>:  <span class="val">#9a8530</span>;        <span class="com">/* lichen (darker) */</span>
+  <span class="var">--line</span>:      <span class="val">rgba(26,30,42,0.12)</span>;
+  <span class="var">--line-hi</span>:   <span class="val">rgba(26,30,42,0.25)</span>;
+}
+[data-theme=<span class="val">"light"</span>] .aurora__blob { mix-blend-mode: <span class="val">multiply</span>; }
+[data-theme=<span class="val">"light"</span>] .grain { opacity: <span class="val">0.03</span>; mix-blend-mode: <span class="val">multiply</span>; }</div>
+
+  <h3 class="t-mono-sm" style="margin:2rem 0 1rem">Toggle-knapp (HTML + JS)</h3>
+  <div class="code" data-lang="HTML" data-copy='<button class="theme-toggle" id="themeToggle" aria-label="Bytt tema"></button>
+
+<script>
+(function(){
+  var btn = document.getElementById("themeToggle");
+  var stored = localStorage.getItem("nordlys-theme");
+  if (stored) document.documentElement.setAttribute("data-theme", stored);
+  btn.addEventListener("click", function(){
+    var next = document.documentElement.getAttribute("data-theme") === "light" ? "dark" : "light";
+    document.documentElement.setAttribute("data-theme", next);
+    localStorage.setItem("nordlys-theme", next);
+  });
+})();
+</script>'>&lt;button class="theme-toggle" id="themeToggle" aria-label="Bytt tema"&gt;&lt;/button&gt;
+
+&lt;script&gt;
+(<span class="key">function</span>(){
+  <span class="key">var</span> btn = document.getElementById(<span class="val">"themeToggle"</span>);
+  <span class="key">var</span> stored = localStorage.getItem(<span class="val">"nordlys-theme"</span>);
+  <span class="key">if</span> (stored) document.documentElement.setAttribute(<span class="val">"data-theme"</span>, stored);
+  btn.addEventListener(<span class="val">"click"</span>, <span class="key">function</span>(){
+    <span class="key">var</span> next = document.documentElement.getAttribute(<span class="val">"data-theme"</span>) === <span class="val">"light"</span> ? <span class="val">"dark"</span> : <span class="val">"light"</span>;
+    document.documentElement.setAttribute(<span class="val">"data-theme"</span>, next);
+    localStorage.setItem(<span class="val">"nordlys-theme"</span>, next);
+  });
+})();
+&lt;/script&gt;</div>
+
+  <h3 class="t-mono-sm" style="margin:2rem 0 1rem">Regler</h3>
+  <ul class="t-body" style="padding-left:1.4rem;display:flex;flex-direction:column;gap:0.6rem;max-width:65ch">
+    <li>Bruk kun CSS-variabler for farger — aldri hardkodede hex-verdier. Da fungerer temaskiftet automatisk.</li>
+    <li>Aurora-blobene bruker <code style="color:var(--aurora-1);font-family:'JetBrains Mono',monospace">multiply</code> i light mode (i stedet for <code style="color:var(--aurora-1);font-family:'JetBrains Mono',monospace">screen</code>) for riktig blending.</li>
+    <li>Test alltid begge temaer. Prøv toggle-knappen oppe til høyre.</li>
+  </ul>
+</section>
+
 <footer class="kit-foot">
   <div>Team Nordlys · Krafthack 2026 · Style Kit v1.0</div>
   <div style="margin-top:0.4rem">Referanse: <a href="index.html">stage/index.html</a></div>
 </footer>
 
 <div class="toast" id="toast">KOPIERT</div>
+
+<script>
+/* ── Theme toggle ── */
+(function(){
+  var btn = document.getElementById('themeToggle');
+  var lbl = document.getElementById('themeLabel');
+  var stored = localStorage.getItem('nordlys-theme');
+  if (stored) { document.documentElement.setAttribute('data-theme', stored); lbl.textContent = stored; }
+  btn.addEventListener('click', function(){
+    var current = document.documentElement.getAttribute('data-theme');
+    var next = current === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('nordlys-theme', next);
+    lbl.textContent = next;
+  });
+})();
+</script>
 
 <script>
 const toast = document.getElementById('toast');


### PR DESCRIPTION
## Summary

- **Events detail page** (`/events/ui/detail`) — click any event in the dashboard feed to see full details
- **Improved events table** — now shows description (truncated) and company as separate columns
- **Dashboard feed fix** — shows event title and company instead of empty description/source
- **New pages** — indicators, chat, vulnerabilities with full CRUD
- **Dark/light theme toggle** — added to style-kit (section 06) and all 9 dashboard pages, persisted via localStorage

## Changes

| Area | What |
|---|---|
| `stage/style-kit.html` | Light mode variables, toggle component, section 06 docs |
| `app/backend/static/*.html` | Theme toggle + light overrides on all pages |
| `app/backend/main.py` | New endpoints: event detail, ingest, chat, vulnerabilities |
| `app/backend/db.py` | Extended schema for indicators, vulnerabilities, chat |
| `app/backend/gossip.py` | Protocol improvements |
